### PR TITLE
Add websocket serving and open-loop evaluation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,38 @@
+# ==========================================
+# Build: docker build -t lerobot .
+# Run:   docker run -it --rm --gpus all lerobot bash
+# ==========================================
+
+FROM nvidia/cuda:12.4.1-base-ubuntu22.04
+
+# -------- Python & 环境 --------
+ARG PYTHON_VERSION=3.10
+ENV DEBIAN_FRONTEND=noninteractive \
+    MUJOCO_GL=egl \
+    PATH="/opt/venv/bin:$PATH"
+
+# 安装依赖 & Python
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential cmake git \
+    libglib2.0-0 libgl1-mesa-glx libegl1-mesa ffmpeg \
+    speech-dispatcher libgeos-dev curl wget vim \
+    python${PYTHON_VERSION}-dev python${PYTHON_VERSION}-venv \
+ && ln -s /usr/bin/python${PYTHON_VERSION} /usr/bin/python \
+ && python -m venv /opt/venv \
+ && echo "source /opt/venv/bin/activate" >> /root/.bashrc \
+ && apt-get clean && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /lerobot
+COPY . .
+
+RUN /opt/venv/bin/pip install --upgrade --no-cache-dir pip \
+ && /opt/venv/bin/pip install --no-cache-dir -e ".[test, aloha, xarm, pusht, dynamixel, serving, pi0]" \
+ && /opt/venv/bin/pip install --no-cache-dir esdk-obs-python==3.22.2
+
+# -------- 下载模型 (可选，允许构建时跳过) --------
+ARG DOWNLOAD_MODELS=true
+RUN if [ "$DOWNLOAD_MODELS" = "true" ]; then \
+    mkdir -p /root/.cache/torch/hub/checkpoints && \
+    wget -q --show-progress -P /root/.cache/torch/hub/checkpoints \
+    https://download.pytorch.org/models/resnet18-f37072fd.pth ; \
+    fi

--- a/lerobot/common/datasets/lerobot_dataset.py
+++ b/lerobot/common/datasets/lerobot_dataset.py
@@ -103,14 +103,6 @@ class LeRobotDatasetMetadata:
 
     def load_metadata(self):
         self.info = load_info(self.root)
-        # self.info['features']['observation.state']['shape'] = (13,)
-        # self.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
-        #                                                        'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum']
-        # self.info['features']['action']['shape'] = (13,)
-        # self.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
-        #                                             'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp']
-        
-        
         check_version_compatibility(self.repo_id, self._version, CODEBASE_VERSION)
         self.tasks, self.task_to_task_index = load_tasks(self.root)
         self.episodes = load_episodes(self.root)
@@ -118,15 +110,7 @@ class LeRobotDatasetMetadata:
             self.stats = load_stats(self.root)
             self.episodes_stats = backward_compatible_episodes_stats(self.stats, self.episodes)
         else:
-            # print("v2.1 episode stat process")
             self.episodes_stats = load_episodes_stats(self.root)
-            # print("episode stats: ", type(self.episodes_stats))
-            # for _, episode_stats in self.episodes_stats.items():
-            #     for feature in ['observation.state', 'action']:
-            #         for sub_feature in ['min', 'max', 'mean', 'std']:
-            #             episode_stats[feature][sub_feature] = np.delete(episode_stats[feature][sub_feature], [6,13], axis=0)
-                        # print('after process', feature, sub_feature, episode_stats[feature][sub_feature].shape)
-                
             self.stats = aggregate_stats(list(self.episodes_stats.values()))
 
     def pull_from_repo(
@@ -747,17 +731,6 @@ class LeRobotDataset(torch.utils.data.Dataset):
             query_result = self._query_hf_dataset(query_indices)
             item = {**item, **padding}
             for key, val in query_result.items():
-                # # remove gripper in original data
-                # if "observation.state" == key:
-                #     keep_cols = [i for i in range(15) if i not in {6, 13}]
-                #     # 切片操作删除指定列
-                #     val = val[:, keep_cols]
-                #     # print("emmmmmm in __getitem_ state", val.shape)
-                # if "action" == key:
-                #     keep_cols = [i for i in range(15) if i not in {6, 13}]
-                #     # 切片操作删除指定列
-                #     val = val[:, keep_cols]
-                #     # print("emmmmmm in __getitem_ action", val.shape)
                 item[key] = val
 
         if len(self.meta.video_keys) > 0:

--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -419,6 +419,9 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
             type = FeatureType.ACTION
         else:
             continue
+        
+        if 'depth' in key:
+            continue
 
         policy_features[key] = PolicyFeature(
             type=type,

--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -419,9 +419,6 @@ def dataset_to_policy_features(features: dict[str, dict]) -> dict[str, PolicyFea
             type = FeatureType.ACTION
         else:
             continue
-        
-        if 'depth' in key:
-            continue
 
         policy_features[key] = PolicyFeature(
             type=type,

--- a/lerobot/common/datasets/utils.py
+++ b/lerobot/common/datasets/utils.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from pprint import pformat
 from types import SimpleNamespace
 from typing import Any
+import copy
 
 import datasets
 import jsonlines
@@ -240,7 +241,7 @@ def load_episodes_stats(local_dir: Path) -> dict:
 def backward_compatible_episodes_stats(
     stats: dict[str, dict[str, np.ndarray]], episodes: list[int]
 ) -> dict[str, dict[str, np.ndarray]]:
-    return {ep_idx: stats for ep_idx in episodes}
+    return {ep_idx: copy.deepcopy(stats) for ep_idx in episodes}
 
 
 def load_image_as_numpy(

--- a/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
@@ -59,7 +59,8 @@ def convert_dataset(
     num_workers: int = 4,
 ):
     with SuppressWarnings():
-        dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
+        # dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
+        dataset = LeRobotDataset("move_reel_test_0322")
 
     if (dataset.root / EPISODES_STATS_PATH).is_file():
         (dataset.root / EPISODES_STATS_PATH).unlink()

--- a/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
@@ -59,8 +59,7 @@ def convert_dataset(
     num_workers: int = 4,
 ):
     with SuppressWarnings():
-        # dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
-        dataset = LeRobotDataset("move_reel_test_0322")
+        dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
 
     if (dataset.root / EPISODES_STATS_PATH).is_file():
         (dataset.root / EPISODES_STATS_PATH).unlink()

--- a/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
+++ b/lerobot/common/datasets/v21/convert_dataset_v20_to_v21.py
@@ -55,11 +55,14 @@ class SuppressWarnings:
 
 def convert_dataset(
     repo_id: str,
+    root: str | None = None,
     branch: str | None = None,
     num_workers: int = 4,
+    sync : bool = False,
+    upload: bool = False
 ):
     with SuppressWarnings():
-        dataset = LeRobotDataset(repo_id, revision=V20, force_cache_sync=True)
+        dataset = LeRobotDataset(repo_id, root=root, revision=V20, force_cache_sync=sync)
 
     if (dataset.root / EPISODES_STATS_PATH).is_file():
         (dataset.root / EPISODES_STATS_PATH).unlink()
@@ -71,21 +74,23 @@ def convert_dataset(
     dataset.meta.info["codebase_version"] = CODEBASE_VERSION
     write_info(dataset.meta.info, dataset.root)
 
-    dataset.push_to_hub(branch=branch, tag_version=False, allow_patterns="meta/")
+    if upload:
+        dataset.push_to_hub(branch=branch, tag_version=False, allow_patterns="meta/")
 
     # delete old stats.json file
     if (dataset.root / STATS_PATH).is_file:
         (dataset.root / STATS_PATH).unlink()
 
-    hub_api = HfApi()
-    if hub_api.file_exists(
-        repo_id=dataset.repo_id, filename=STATS_PATH, revision=branch, repo_type="dataset"
-    ):
-        hub_api.delete_file(
-            path_in_repo=STATS_PATH, repo_id=dataset.repo_id, revision=branch, repo_type="dataset"
-        )
+    if upload:
+        hub_api = HfApi()
+        if hub_api.file_exists(
+            repo_id=dataset.repo_id, filename=STATS_PATH, revision=branch, repo_type="dataset"
+        ):
+            hub_api.delete_file(
+                path_in_repo=STATS_PATH, repo_id=dataset.repo_id, revision=branch, repo_type="dataset"
+            )
 
-    hub_api.create_tag(repo_id, tag=CODEBASE_VERSION, revision=branch, repo_type="dataset")
+        hub_api.create_tag(repo_id, tag=CODEBASE_VERSION, revision=branch, repo_type="dataset")
 
 
 if __name__ == "__main__":
@@ -108,6 +113,12 @@ if __name__ == "__main__":
         type=int,
         default=4,
         help="Number of workers for parallelizing stats compute. Defaults to 4.",
+    )
+    parser.add_argument(
+        "--root",
+        type=str,
+        default=None,
+        help="local root data dir.",
     )
 
     args = parser.parse_args()

--- a/lerobot/common/policies/act/modeling_act.py
+++ b/lerobot/common/policies/act/modeling_act.py
@@ -107,6 +107,20 @@ class ACTPolicy(PreTrainedPolicy):
             self._action_queue = deque([], maxlen=self.config.n_action_steps)
 
     @torch.no_grad
+    def select_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        """Select the entire action chunk given environment observations.
+
+        This method wraps `select_action_chunk` in order to return all actions the policy infers at a time.
+        Resuse the `select_action` method in order to reuse the open source lerobot, but its performance may
+        decrease a bit.
+        """
+        first_action = self.select_action(batch)        
+        result_tensor = torch.cat([first_action] + list(self._action_queue), dim=0)
+        self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        return result_tensor
+
+
+    @torch.no_grad
     def select_action(self, batch: dict[str, Tensor]) -> Tensor:
         """Select a single action given environment observations.
 

--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -143,6 +143,19 @@ class DiffusionPolicy(PreTrainedPolicy):
         action = self._queues["action"].popleft()
         return action
 
+    @torch.no_grad
+    def select_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        """Select the entire action chunk given environment observations.
+
+        This method wraps `select_action_chunk` in order to return all actions the policy infers at a time.
+        Resuse the `select_action` method in order to reuse the open source lerobot, but its performance may
+        decrease a bit.
+        """
+        first_action = self.select_action(batch)        
+        result_tensor = torch.cat([first_action] + list(self._action_queue), dim=0)
+        self._action_queue = deque([], maxlen=self.config.n_action_steps)
+        return result_tensor
+
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, None]:
         """Run the batch through the model and compute the loss for training or validation."""
         batch = self.normalize_inputs(batch)

--- a/lerobot/common/policies/diffusion/modeling_diffusion.py
+++ b/lerobot/common/policies/diffusion/modeling_diffusion.py
@@ -151,10 +151,27 @@ class DiffusionPolicy(PreTrainedPolicy):
         Resuse the `select_action` method in order to reuse the open source lerobot, but its performance may
         decrease a bit.
         """
-        first_action = self.select_action(batch)        
-        result_tensor = torch.cat([first_action] + list(self._action_queue), dim=0)
-        self._action_queue = deque([], maxlen=self.config.n_action_steps)
-        return result_tensor
+        batch = self.normalize_inputs(batch)
+        if self.config.image_features:
+            batch = dict(batch)  # shallow copy so that adding a key doesn't modify the original
+            batch["observation.images"] = torch.stack(
+                [batch[key] for key in self.config.image_features], dim=-4
+            )
+        # Note: It's important that this happens after stacking the images into a single key.
+        self._queues = populate_queues(self._queues, batch)
+
+        # if len(self._queues["action"]) == 0:
+        # stack n latest observations from the queue
+        batch = {k: torch.stack(list(self._queues[k]), dim=1) for k in batch if k in self._queues}
+        actions = self.diffusion.generate_actions(batch)
+
+        # TODO(rcadene): make above methods return output dictionary?
+        actions = self.unnormalize_outputs({"action": actions})["action"]
+        return actions
+        # self._queues["action"].extend(actions.transpose(0, 1))
+
+        # action = self._queues["action"].popleft()
+        # return action
 
     def forward(self, batch: dict[str, Tensor]) -> tuple[Tensor, None]:
         """Run the batch through the model and compute the loss for training or validation."""

--- a/lerobot/common/policies/normalize.py
+++ b/lerobot/common/policies/normalize.py
@@ -168,6 +168,7 @@ class Normalize(nn.Module):
                 std = buffer["std"]
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
+                print("process key:", key)
                 batch[key] = (batch[key] - mean) / (std + 1e-8)
             elif norm_mode is NormalizationMode.MIN_MAX:
                 min = buffer["min"]

--- a/lerobot/common/policies/normalize.py
+++ b/lerobot/common/policies/normalize.py
@@ -168,7 +168,6 @@ class Normalize(nn.Module):
                 std = buffer["std"]
                 assert not torch.isinf(mean).any(), _no_stats_error_str("mean")
                 assert not torch.isinf(std).any(), _no_stats_error_str("std")
-                print("process key:", key)
                 batch[key] = (batch[key] - mean) / (std + 1e-8)
             elif norm_mode is NormalizationMode.MIN_MAX:
                 min = buffer["min"]

--- a/lerobot/common/policies/pi0/modeling_pi0.py
+++ b/lerobot/common/policies/pi0/modeling_pi0.py
@@ -259,6 +259,10 @@ class PI0Policy(PreTrainedPolicy):
 
     def get_optim_params(self) -> dict:
         return self.parameters()
+    
+    @torch.no_grad
+    def select_action_chunk(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
+        raise NotImplementedError("")
 
     @torch.no_grad
     def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:

--- a/lerobot/common/policies/pi0/modeling_pi0.py
+++ b/lerobot/common/policies/pi0/modeling_pi0.py
@@ -262,7 +262,36 @@ class PI0Policy(PreTrainedPolicy):
     
     @torch.no_grad
     def select_action_chunk(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
-        raise NotImplementedError("")
+        self.eval()
+
+        if self.config.adapt_to_pi_aloha:
+            batch[OBS_ROBOT] = self._pi_aloha_decode_state(batch[OBS_ROBOT])
+
+        batch = self.normalize_inputs(batch)
+
+        # Action queue logic for n_action_steps > 1. When the action_queue is depleted, populate it by
+        # querying the policy.
+        images, img_masks = self.prepare_images(batch)
+        state = self.prepare_state(batch)
+        lang_tokens, lang_masks = self.prepare_language(batch)
+
+        actions = self.model.sample_actions(
+            images, img_masks, lang_tokens, lang_masks, state, noise=noise
+        )
+
+        # Unpad actions
+        original_action_dim = self.config.action_feature.shape[0]
+        actions = actions[:, :, :original_action_dim]
+
+        actions = self.unnormalize_outputs({"action": actions})["action"]
+
+        if self.config.adapt_to_pi_aloha:
+            actions = self._pi_aloha_encode_actions(actions)
+
+        # `self.model.forward` returns a (batch_size, n_action_steps, action_dim) tensor, but the queue
+        # effectively has shape (n_action_steps, batch_size, *), hence the transpose.
+        return actions
+
 
     @torch.no_grad
     def select_action(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:

--- a/lerobot/common/policies/pi0fast/modeling_pi0fast.py
+++ b/lerobot/common/policies/pi0fast/modeling_pi0fast.py
@@ -191,6 +191,10 @@ class PI0FASTPolicy(PreTrainedPolicy):
         for motor_idx in [6, 13]:
             actions[:, :, motor_idx] = aloha_gripper_from_angular_inv(actions[:, :, motor_idx])
         return actions
+    
+    @torch.no_grad
+    def select_action_chunk(self, batch: dict[str, Tensor], noise: Tensor | None = None) -> Tensor:
+        raise NotImplementedError("")
 
     @torch.no_grad
     def select_action(self, batch: dict[str, Tensor]) -> Tensor:

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -197,3 +197,12 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         with caching.
         """
         raise NotImplementedError
+    
+    @abc.abstractmethod
+    def select_action_chunk(self, batch: dict[str, Tensor]) -> Tensor:
+        """Return one action to run in the environment (potentially in batch mode).
+
+        When the model uses a history of observations, or outputs a sequence of actions, this method deals
+        with caching.
+        """
+        raise NotImplementedError

--- a/lerobot/common/policies/pretrained.py
+++ b/lerobot/common/policies/pretrained.py
@@ -28,6 +28,7 @@ from torch import Tensor, nn
 
 from lerobot.common.utils.hub import HubMixin
 from lerobot.configs.policies import PreTrainedConfig
+from lerobot.configs.obs_utils import contains_obs_url, download_policy_file
 
 T = TypeVar("T", bound="PreTrainedPolicy")
 
@@ -110,6 +111,11 @@ class PreTrainedPolicy(nn.Module, HubMixin, abc.ABC):
         if os.path.isdir(model_id):
             print("Loading weights from local directory")
             model_file = os.path.join(model_id, SAFETENSORS_SINGLE_FILE)
+            policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
+        elif contains_obs_url(model_id):
+            dest_dir = download_policy_file(model_id)
+            print("Loading weights from local directory")
+            model_file = os.path.join(dest_dir, SAFETENSORS_SINGLE_FILE)
             policy = cls._load_as_safetensor(instance, model_file, config.device, strict)
         else:
             try:

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -94,9 +94,10 @@ class WebsocketPolicyServer:
                     if isinstance(obs[key], torch.Tensor):
                         obs[key] = obs[key].to("cuda", non_blocking=True)
                         
-                with torch.inference_mode():     
-                    action = self._policy.select_action(obs)
-                    print("inference once with action:", action)
+                with torch.inference_mode():
+                    action = self._policy.select_action_chunk(obs)
+                    action = action.squeeze(0)
+                    print("inference once with action:", action.shape, action)
                     res = {"actions": action.cpu().numpy()}
                 await websocket.send(packer.pack(res))
             except websockets.ConnectionClosed:

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -1,0 +1,111 @@
+import asyncio
+import logging
+import traceback
+import einops
+
+import numpy as np
+import torch
+import websockets.asyncio.server
+import websockets.frames
+
+import lerobot.common.utils.msgpack_utils as msgpack_utils
+from lerobot.common.policies.pretrained import PreTrainedPolicy
+
+class WebsocketPolicyServer:
+    """Serves a policy using the websocket protocol. See websocket_client_policy.py for a client implementation.
+
+    Currently only implements the `load` and `infer` methods.
+    """
+
+    def __init__(
+        self,
+        policy: PreTrainedPolicy,
+        host: str = "0.0.0.0",
+        port: int = 8000,
+        metadata: dict | None = None,
+    ) -> None:
+        self._policy = policy
+        self._host = host
+        self._port = port
+        self._metadata = metadata or {}        
+
+    def serve_forever(self) -> None:
+        asyncio.run(self.run())
+
+    async def run(self):
+        async with websockets.asyncio.server.serve(
+            self._handler,
+            self._host,
+            self._port,
+            compression=None,
+            max_size=None,
+        ) as server:
+            await server.serve_forever()
+            
+    async def preprocess_observation(self, observations: dict) -> dict[str, torch.Tensor]:
+        images = observations['images']
+        return_observations = {}
+        
+        for imgkey, img in images.items():
+            img = torch.from_numpy(img)
+            img = einops.rearrange(img, "h w c -> c h w").contiguous()
+            c, h, w = img.shape
+            if h == 360:
+                img = torch.nn.functional.pad(img,pad=(0, 0, 60, 60), mode='constant', value=0)
+            c, h, w = img.shape
+
+            assert c < h and c < w, f"expect channel last images, but instead got {img.shape=}"
+            assert img.dtype == torch.uint8, f"expect torch.uint8, but instead {img.dtype=}"
+            img = img.unsqueeze(0)
+            img = img.type(torch.float32)
+            img /= 255
+            
+            imgkey = f"observation.images.{imgkey}"
+            print('add a key: ', imgkey, img.shape)
+            return_observations[imgkey] = img
+            
+        return_observations["observation.state"] = torch.from_numpy(observations["state"]).float()
+        return_observations["observation.state"] = return_observations["observation.state"].unsqueeze(0)
+        
+        return return_observations
+            
+
+    async def _handler(self, websocket: websockets.asyncio.server.ServerConnection):
+        logging.info(f"Connection from {websocket.remote_address} opened")
+        packer = msgpack_utils.Packer()
+
+        await websocket.send(packer.pack(self._metadata))
+
+        while True:
+            try:
+                # example
+                # obs = {
+                #     "images": {
+                #         "cam_high": numpy.NDArray,
+                #         "cam_right_wrist": numpy.NDArray,
+                #     },
+                #     "state": numpy.NDarray,
+                #     "prompt": "xxx text"
+                # }
+                obs = msgpack_utils.unpackb(await websocket.recv())
+                
+                obs = await self.preprocess_observation(obs)
+                for key in obs:
+                    if isinstance(obs[key], torch.Tensor):
+                        obs[key] = obs[key].to("cuda", non_blocking=True)
+                        
+                with torch.inference_mode():     
+                    action = self._policy.select_action(obs)
+                    print("inference once with action:", action)
+                    res = {"actions": action.cpu().numpy()}
+                await websocket.send(packer.pack(res))
+            except websockets.ConnectionClosed:
+                logging.info(f"Connection from {websocket.remote_address} closed")
+                break
+            except Exception:
+                await websocket.send(traceback.format_exc())
+                await websocket.close(
+                    code=websockets.frames.CloseCode.INTERNAL_ERROR,
+                    reason="Internal server error. Traceback included in previous frame.",
+                )
+                raise

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -31,7 +31,8 @@ class WebsocketPolicyServer:
         self._policy = policy
         self._host = host
         self._port = port
-        self._metadata = metadata or {}  
+        self._metadata = metadata or {}
+        self._stop_event = asyncio.Event()
         
         self._trace_enable = False
         self._wandb_enable = False
@@ -52,7 +53,7 @@ class WebsocketPolicyServer:
                 ),
                 on_trace_ready=lambda prof: prof.export_chrome_trace(f"tmp/trace_schedule_{prof.step_num}.json"),
             )
-              
+
         else:
             self._trace_enable = False
 
@@ -67,8 +68,11 @@ class WebsocketPolicyServer:
             compression=None,
             max_size=None,
         ) as server:
-            await server.serve_forever()
-            
+            # await server.serve_forever()
+            print("WebSocket server started. Waiting for 'exit' command to shutdown.")
+            await self._stop_event.wait()
+            print("Shutdown event received. Server exiting.")
+
     async def preprocess_observation(self, observations: dict) -> dict[str, torch.Tensor]:
         images = observations['images']
         return_observations = {}
@@ -102,43 +106,39 @@ class WebsocketPolicyServer:
 
         while True:
             try:
-                # example
-                # obs = {
-                #     "images": {
-                #         "cam_high": numpy.NDArray,
-                #         "cam_right_wrist": numpy.NDArray,
-                #     },
-                #     "state": numpy.NDarray,
-                #     "prompt": "xxx text"
-                # }
-                obs = msgpack_utils.unpackb(await websocket.recv())
-                
-                obs = await self.preprocess_observation(obs)
-                for key in obs:
-                    if isinstance(obs[key], torch.Tensor):
-                        obs[key] = obs[key].to(self._policy.config.device, non_blocking=True)
-                
-                if self._wandb_enable:
-                    start_time = time.perf_counter()
-                
-                with torch.inference_mode(), record_function('eval_policy') if self._trace_enable else nullcontext():
-                    if self._trace_enable:
-                        self._profiler.step()
-                    action = self._policy.select_action_chunk(obs)
-                                    
-                if self._wandb_enable:
-                    if self._infer_cnt < self._drop_first_n_frames:
-                        self._infer_cnt = self._infer_cnt + 1
-                    else:
-                        infer_cost_ms = (time.perf_counter() - start_time) * 1000
-                        log_dict = {
-                            "infer_cost_ms": infer_cost_ms
-                        }  
-                        wandb.log(log_dict)
-                action = action.squeeze(0)
-                # print("inference once with action:", action.shape, action)
-                res = {"actions": action.cpu().numpy()}
-                await websocket.send(packer.pack(res))
+                obs = msgpack_utils.unpackb(await websocket.recv(), raw=False)
+                if isinstance(obs, dict) and obs.get("command") == "exit":
+                    logging.info(f"Received exit command from {websocket.remote_address}. Shutting down server.")
+                    await websocket.send(packer.pack({"status": "Server is shutting down."}))
+                    self._stop_event.set()
+                else:
+                    # obs = msgpack_utils.unpackb(await websocket.recv())
+                    obs = await self.preprocess_observation(obs)
+                    for key in obs:
+                        if isinstance(obs[key], torch.Tensor):
+                            obs[key] = obs[key].to(self._policy.config.device, non_blocking=True)
+
+                    if self._wandb_enable:
+                        start_time = time.perf_counter()
+
+                    with torch.inference_mode(), record_function('eval_policy') if self._trace_enable else nullcontext():
+                        if self._trace_enable:
+                            self._profiler.step()
+                        action = self._policy.select_action_chunk(obs)
+
+                    if self._wandb_enable:
+                        if self._infer_cnt < self._drop_first_n_frames:
+                            self._infer_cnt = self._infer_cnt + 1
+                        else:
+                            infer_cost_ms = (time.perf_counter() - start_time) * 1000
+                            log_dict = {
+                                "infer_cost_ms": infer_cost_ms
+                            }
+                            wandb.log(log_dict)
+                    action = action.squeeze(0)
+                    # print("inference once with action:", action.shape, action)
+                    res = {"actions": action.cpu().numpy()}
+                    await websocket.send(packer.pack(res))
             except websockets.ConnectionClosed:
                 logging.info(f"Connection from {websocket.remote_address} closed")
                 break

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -62,6 +62,7 @@ class WebsocketPolicyServer:
             
         return_observations["observation.state"] = torch.from_numpy(observations["state"]).float()
         return_observations["observation.state"] = return_observations["observation.state"].unsqueeze(0)
+        return_observations["task"] = [observations["prompt"]]
         
         return return_observations
             

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -2,7 +2,9 @@ import asyncio
 import logging
 import traceback
 import einops
+import time
 
+import wandb
 import numpy as np
 import torch
 import websockets.asyncio.server
@@ -27,7 +29,13 @@ class WebsocketPolicyServer:
         self._policy = policy
         self._host = host
         self._port = port
-        self._metadata = metadata or {}        
+        self._metadata = metadata or {}  
+        if self._metadata['wandb_enable']:
+            self._wandb_enable = True
+            self._drop_first_n_frames = self._metadata['drop_first_n_frames']
+            self._infer_cnt = 0
+        else:
+            self._wandb_enable = False
 
     def serve_forever(self) -> None:
         asyncio.run(self.run())
@@ -57,7 +65,7 @@ class WebsocketPolicyServer:
             img /= 255
             
             imgkey = f"observation.images.{imgkey}"
-            print('add a key: ', imgkey, img.shape)
+            # print('add a key: ', imgkey, img.shape)
             return_observations[imgkey] = img
             
         return_observations["observation.state"] = torch.from_numpy(observations["state"]).float()
@@ -89,13 +97,26 @@ class WebsocketPolicyServer:
                 obs = await self.preprocess_observation(obs)
                 for key in obs:
                     if isinstance(obs[key], torch.Tensor):
-                        obs[key] = obs[key].to("cuda", non_blocking=True)
-                        
+                        obs[key] = obs[key].to(self._policy.config.device, non_blocking=True)
+                
+                if self._wandb_enable:
+                    start_time = time.perf_counter()
+                
                 with torch.inference_mode():
                     action = self._policy.select_action_chunk(obs)
-                    action = action.squeeze(0)
-                    print("inference once with action:", action.shape, action)
-                    res = {"actions": action.cpu().numpy()}
+                
+                if self._wandb_enable:
+                    if self._infer_cnt < self._drop_first_n_frames:
+                        self._infer_cnt = self._infer_cnt + 1
+                    else:
+                        infer_cost_ms = (time.perf_counter() - start_time) * 1000
+                        log_dict = {
+                            "infer_cost_ms": infer_cost_ms
+                        }  
+                        wandb.log(log_dict)
+                action = action.squeeze(0)
+                # print("inference once with action:", action.shape, action)
+                res = {"actions": action.cpu().numpy()}
                 await websocket.send(packer.pack(res))
             except websockets.ConnectionClosed:
                 logging.info(f"Connection from {websocket.remote_address} closed")

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -3,10 +3,12 @@ import logging
 import traceback
 import einops
 import time
+from contextlib import nullcontext
 
 import wandb
 import numpy as np
 import torch
+from torch.profiler import profile, record_function, ProfilerActivity
 import websockets.asyncio.server
 import websockets.frames
 
@@ -30,12 +32,29 @@ class WebsocketPolicyServer:
         self._host = host
         self._port = port
         self._metadata = metadata or {}  
+        
+        self._trace_enable = False
+        self._wandb_enable = False
         if self._metadata['wandb_enable']:
             self._wandb_enable = True
             self._drop_first_n_frames = self._metadata['drop_first_n_frames']
             self._infer_cnt = 0
+        if self._metadata['trace_enable']:
+            self._trace_enable = True
+            self._profiler = profile(
+                activities=[ProfilerActivity.CPU, ProfilerActivity.CUDA],
+                record_shapes=True,
+                with_flops=True,
+                schedule=torch.profiler.schedule(
+                    wait=1,
+                    warmup=1,
+                    active=5
+                ),
+                on_trace_ready=lambda prof: prof.export_chrome_trace(f"tmp/trace_schedule_{prof.step_num}.json"),
+            )
+              
         else:
-            self._wandb_enable = False
+            self._trace_enable = False
 
     def serve_forever(self) -> None:
         asyncio.run(self.run())
@@ -102,9 +121,11 @@ class WebsocketPolicyServer:
                 if self._wandb_enable:
                     start_time = time.perf_counter()
                 
-                with torch.inference_mode():
+                with torch.inference_mode(), record_function('eval_policy') if self._trace_enable else nullcontext():
+                    if self._trace_enable:
+                        self._profiler.step()
                     action = self._policy.select_action_chunk(obs)
-                
+                                    
                 if self._wandb_enable:
                     if self._infer_cnt < self._drop_first_n_frames:
                         self._infer_cnt = self._infer_cnt + 1

--- a/lerobot/common/serving/websocket_policy_server.py
+++ b/lerobot/common/serving/websocket_policy_server.py
@@ -50,10 +50,6 @@ class WebsocketPolicyServer:
             img = torch.from_numpy(img)
             img = einops.rearrange(img, "h w c -> c h w").contiguous()
             c, h, w = img.shape
-            if h == 360:
-                img = torch.nn.functional.pad(img,pad=(0, 0, 60, 60), mode='constant', value=0)
-            c, h, w = img.shape
-
             assert c < h and c < w, f"expect channel last images, but instead got {img.shape=}"
             assert img.dtype == torch.uint8, f"expect torch.uint8, but instead {img.dtype=}"
             img = img.unsqueeze(0)

--- a/lerobot/common/utils/image_utils.py
+++ b/lerobot/common/utils/image_utils.py
@@ -1,0 +1,44 @@
+import einops
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+def resize_with_pad_train(images: torch.Tensor, target_height: int, target_width: int) -> np.ndarray:
+    """Replicates tf.image.resize_with_pad for multiple images using PIL. Resizes a batch of images to a target height.
+
+    Args:
+        images: A batch of images in [..., channel, height, width] format.
+        height: The target height of the image.
+        width: The target width of the image.
+        method: The interpolation method to use. Default is bilinear.
+
+    Returns:
+        The resized images in [..., height, width, channel].
+    """
+    original_shape = None
+    if len(images.shape) == 5:
+        original_shape = images.shape
+        images = images.view(-1, *original_shape[-3:])
+    
+    height, width = images.shape[-2], images.shape[-1]
+    if height == target_height and width == target_width:
+        return images    
+    
+    # scale either height or width to the given value
+    scale = min(target_height / height, target_width / width)
+    new_height = int(scale * height)
+    new_width = int(scale * width)
+    images = F.interpolate(images, size=(new_height, new_width), mode='bilinear', align_corners=False)
+    
+    # pad the other
+    pad_width = target_width - new_width
+    pad_height = target_height - new_height
+    padding = [
+        pad_width // 2, pad_width - pad_width // 2, pad_height // 2, pad_height - pad_height // 2
+    ]    
+    images = F.pad(images, padding, value=0)
+
+    if original_shape is not None:
+        images = images.view(*original_shape[:-3], *images.shape[-3:])
+    return images
+    

--- a/lerobot/common/utils/msgpack_utils.py
+++ b/lerobot/common/utils/msgpack_utils.py
@@ -1,0 +1,43 @@
+import functools
+
+import msgpack
+import numpy as np
+
+
+def pack_array(obj):
+    if (isinstance(obj, (np.ndarray, np.generic))) and obj.dtype.kind in ("V", "O", "c"):
+        raise ValueError(f"Unsupported dtype: {obj.dtype}")
+
+    if isinstance(obj, np.ndarray):
+        return {
+            b"__ndarray__": True,
+            b"data": obj.tobytes(),
+            b"dtype": obj.dtype.str,
+            b"shape": obj.shape,
+        }
+
+    if isinstance(obj, np.generic):
+        return {
+            b"__npgeneric__": True,
+            b"data": obj.item(),
+            b"dtype": obj.dtype.str,
+        }
+
+    return obj
+
+
+def unpack_array(obj):
+    if b"__ndarray__" in obj:
+        return np.ndarray(buffer=obj[b"data"], dtype=np.dtype(obj[b"dtype"]), shape=obj[b"shape"])
+
+    if b"__npgeneric__" in obj:
+        return np.dtype(obj[b"dtype"]).type(obj[b"data"])
+
+    return obj
+
+
+Packer = functools.partial(msgpack.Packer, default=pack_array)
+packb = functools.partial(msgpack.packb, default=pack_array)
+
+Unpacker = functools.partial(msgpack.Unpacker, object_hook=unpack_array)
+unpackb = functools.partial(msgpack.unpackb, object_hook=unpack_array)

--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -24,6 +24,9 @@ from pathlib import Path
 
 import numpy as np
 import torch
+if hasattr(torch, 'npu'):
+    import torch_npu
+    logging.info("exists npu, import torch_npu")
 
 
 def none_or_int(value):
@@ -46,6 +49,9 @@ def auto_select_torch_device() -> torch.device:
     elif torch.backends.mps.is_available():
         logging.info("Metal backend detected, using cuda.")
         return torch.device("mps")
+    elif torch_npu.npu.is_available():
+        logging.info("Npu backend detected, using npu.")
+        return torch.device("npu")
     else:
         logging.warning("No accelerated backend detected. Using default cpu, this will be slow.")
         return torch.device("cpu")
@@ -94,8 +100,10 @@ def is_torch_device_available(try_device: str) -> bool:
         return torch.backends.mps.is_available()
     elif try_device == "cpu":
         return True
+    elif try_device == "npu":
+        return torch_npu.npu.is_available()
     else:
-        raise ValueError(f"Unknown device {try_device}. Supported devices are: cuda, mps or cpu.")
+        raise ValueError(f"Unknown device {try_device}. Supported devices are: cuda, mps, cpu or npu.")
 
 
 def is_amp_available(device: str):

--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
-if os.environ['ASCEND_HOME_PATH'] is not None:
+if "ASCEND_HOME_PATH" in os.environ:
     import torch_npu
     logging.info("exists npu, import torch_npu")
 

--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -107,31 +107,38 @@ def is_torch_device_available(try_device: str) -> bool:
 
 
 def is_amp_available(device: str):
-    if device in ["cuda", "cpu"]:
+    if device in ["cuda", "cpu", "npu"]:
         return True
     elif device == "mps":
         return False
     else:
         raise ValueError(f"Unknown device '{device}.")
 
-
-def init_logging():
-    def custom_format(record):
+class CustomFormatter(logging.Formatter):
+    def format(self, record):
         dt = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         fnameline = f"{record.pathname}:{record.lineno}"
+        # 保留原始消息格式，处理可能的参数
+        if record.args:
+            record.msg = record.msg % record.args
+            record.args = None
         message = f"{record.levelname} {dt} {fnameline[-15:]:>15} {record.msg}"
+        # 处理异常信息
+        if record.exc_info:
+            message += "\n" + self.formatException(record.exc_info)
         return message
 
-    logging.basicConfig(level=logging.INFO)
+def init_logging():
+    root_logger = logging.getLogger()
+    root_logger.setLevel(logging.INFO)
 
-    for handler in logging.root.handlers[:]:
-        logging.root.removeHandler(handler)
+    for handler in root_logger.handlers[:]:
+        root_logger.removeHandler(handler)
 
-    formatter = logging.Formatter()
-    formatter.format = custom_format
     console_handler = logging.StreamHandler()
-    console_handler.setFormatter(formatter)
-    logging.getLogger().addHandler(console_handler)
+    console_handler.setFormatter(CustomFormatter())
+    root_logger.addHandler(console_handler)
+
 
 
 def format_big_number(num, precision=0):

--- a/lerobot/common/utils/utils.py
+++ b/lerobot/common/utils/utils.py
@@ -24,7 +24,7 @@ from pathlib import Path
 
 import numpy as np
 import torch
-if hasattr(torch, 'npu'):
+if os.environ['ASCEND_HOME_PATH'] is not None:
     import torch_npu
     logging.info("exists npu, import torch_npu")
 

--- a/lerobot/configs/obs_utils.py
+++ b/lerobot/configs/obs_utils.py
@@ -1,0 +1,170 @@
+import os
+import logging
+import shutil
+import tarfile
+import traceback
+
+from urllib.parse import urlparse
+from obs import ObsClient
+
+
+def get_env_variable(name, default=None):
+    """读取环境变量，如果未设置则返回默认值"""
+    value = os.getenv(name, default)
+    if value is None:
+        raise ValueError(f"The env variable '{name}' is not set and has no default value!")
+    return value
+
+
+class EnvConfig:
+    def __init__(self):
+        # obs
+        self.ACCESS_KEY_ID = get_env_variable("ACCESS_KEY_ID")
+        self.SECRET_ACCESS_KEY = get_env_variable("SECRET_ACCESS_KEY")
+        self.OBS_SERVER = get_env_variable("OBS_SERVER")
+        self.POLICY_CKPT_DIR = get_env_variable("POLICY_CKPT_DIR", "checkpoints")
+
+
+def download_policy_file(obs_url: str) -> str:
+    env_config = EnvConfig()
+    obsClient = ObsClient(access_key_id=env_config.ACCESS_KEY_ID,
+                          secret_access_key=env_config.SECRET_ACCESS_KEY,
+                          server=env_config.OBS_SERVER)
+    dest_dir = env_config.POLICY_CKPT_DIR
+
+    # --- 1. Parse obs_url ---
+    if not obs_url.lower().startswith("obs://"):
+        raise ValueError("Invalid obs_url. Must start with 'obs://'.")
+
+    path = obs_url[6:]
+    parts = path.split('/', 1)
+    if len(parts) != 2:
+        raise ValueError("obs_url must be in format: obs://bucket/prefix")
+
+    bucket_name = parts[0]
+    prefix = parts[1]
+    logging.info(f"bucket_name: {bucket_name}, prefix: {prefix}")
+    if not prefix.endswith('/'):
+        prefix += '/'
+
+    # --- 2. Compute final root path ---
+    root_dir_name = os.path.basename(prefix.rstrip('/'))
+    final_dest_dir = os.path.join(dest_dir, root_dir_name)
+    os.makedirs(final_dest_dir, exist_ok=True)
+
+    # --- 3. List objects ---
+    response = obsClient.listObjects(bucket_name, prefix)
+    objects = response.get("body", {}).get("contents", [])
+
+    # --- 4. Download all files ---
+    for obj in objects:
+        key = obj.get("key", "")
+        size = obj.get("size", 0)
+
+        # Relative path under the prefix
+        relative_path = key[len(prefix):]
+        local_path = os.path.join(final_dest_dir, relative_path)
+
+        if key.endswith("/") and size == 0:
+            os.makedirs(local_path, exist_ok=True)
+            logging.info(f"[Folder] Created local directory: {local_path}")
+        else:
+            os.makedirs(os.path.dirname(local_path), exist_ok=True)
+            file_name = os.path.basename(local_path)
+            local_dir = os.path.dirname(local_path)
+            logging.info(f"[File] Downloading {key} -> {local_path}")
+            try:
+                download_obs_file(
+                    obsClient=obsClient,
+                    bucket_name=bucket_name,
+                    object_key=key,
+                    file_name=file_name,
+                    dest_dir=local_dir
+                )
+            except Exception as e:
+                logging.info(f'Download File Failed {e}')
+                logging.info(traceback.format_exc())
+
+    return final_dest_dir
+
+
+def download_obs_file(obsClient: ObsClient, bucket_name: str, object_key: str, file_name: str, dest_dir: str,
+                      enable_checkpoint: bool = False):
+    download_file = os.path.join(dest_dir, file_name)
+    remove_dir_or_file(download_file)
+    # 分段下载的并发数
+    task_num = 5
+    # 分段的大小
+    part_size = 10 * 1024 * 1024
+    # 断点续传下载对象
+    resp = obsClient.downloadFile(bucket_name, object_key, download_file,
+                                       part_size, task_num, enable_checkpoint)
+    # 返回码为2xx时，接口调用成功，否则接口调用失败
+    if resp.status < 300:
+        logging.info('Download File Succeeded')
+        logging.info(f'requestId: {resp.requestId}')
+    else:
+        logging.info('Download File Failed')
+        logging.info(f'requestId: {resp.requestId}')
+        logging.info(f'errorCode: {resp.errorCode}', )
+        logging.info(f'errorMessage: {resp.errorMessage}')
+
+    return download_file
+
+
+def remove_dir_or_file(target_path):
+    """删除路径对应的文件"""
+    if not os.path.exists(target_path):
+        return
+    logging.warning(f"{target_path} will be remove.")
+    if os.path.isdir(target_path):
+        shutil.rmtree(target_path)
+    else:
+        os.remove(target_path)
+
+
+def parse_obs_url(obs_url: str):
+    """解析华为云 OBS URL，提取 bucketName、objectKey 和 fileName"""
+    parsed_url = urlparse(obs_url)
+
+    # 解析 bucketName（通常是二级域名部分）
+    domain_parts = parsed_url.netloc.split('.')
+    if len(domain_parts) > 1:
+        bucket_name = domain_parts[0]
+    else:
+        raise ValueError("无法解析 bucketName")
+
+    # 解析 objectKey（去掉前导 '/'）
+    object_key = parsed_url.path.lstrip('/')
+
+    # 解析 fileName（objectKey 的最后一部分）
+    file_name = object_key.split('/')[-1] if object_key else ''
+
+    return bucket_name, object_key, file_name
+
+
+def is_tar_gz_file(file_path: str):
+    """判断文件是否是 .tar.gz 结尾的压缩文件"""
+    return file_path.endswith(".tar.gz")
+
+
+def extract_tar_gz(file_path: str, dest_dir: str = None):
+    """解压 .tar.gz 文件到指定目录，如果 dest_dir 为 None，则解压到当前目录"""
+    if not is_tar_gz_file(file_path):
+        raise ValueError("文件不是 .tar.gz 格式")
+
+    if dest_dir is None:
+        dest_dir = os.getcwd()  # 设为当前目录
+
+    os.makedirs(dest_dir, exist_ok=True)  # 确保目标目录存在
+
+    with tarfile.open(file_path, "r:gz") as tar:
+        tar.extractall(path=dest_dir)
+
+    logging.info(f"文件 {file_path} 已解压到 {dest_dir}")
+
+
+def contains_obs_url(s: str) -> bool:
+    if not isinstance(s, str):
+        return False  # 非字符串直接返回 False
+    return 'obs://' in s.strip().lower()

--- a/lerobot/configs/policies.py
+++ b/lerobot/configs/policies.py
@@ -28,6 +28,7 @@ from lerobot.common.optim.schedulers import LRSchedulerConfig
 from lerobot.common.utils.hub import HubMixin
 from lerobot.common.utils.utils import auto_select_torch_device, is_amp_available, is_torch_device_available
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
+from lerobot.configs.obs_utils import contains_obs_url, download_policy_file
 
 # Generic variable that is either PreTrainedConfig or a subclass thereof
 T = TypeVar("T", bound="PreTrainedConfig")
@@ -150,6 +151,12 @@ class PreTrainedConfig(draccus.ChoiceRegistry, HubMixin, abc.ABC):
         if Path(model_id).is_dir():
             if CONFIG_NAME in os.listdir(model_id):
                 config_file = os.path.join(model_id, CONFIG_NAME)
+            else:
+                print(f"{CONFIG_NAME} not found in {Path(model_id).resolve()}")
+        elif contains_obs_url(model_id):
+            dest_dir = download_policy_file(model_id)
+            if CONFIG_NAME in os.listdir(dest_dir):
+                config_file = os.path.join(dest_dir, CONFIG_NAME)
             else:
                 print(f"{CONFIG_NAME} not found in {Path(model_id).resolve()}")
         else:

--- a/lerobot/scripts/eval.py
+++ b/lerobot/scripts/eval.py
@@ -69,6 +69,7 @@ from lerobot.common.envs.factory import make_env
 from lerobot.common.envs.utils import add_envs_task, check_env_attributes_and_types, preprocess_observation
 from lerobot.common.policies.factory import make_policy
 from lerobot.common.policies.pretrained import PreTrainedPolicy
+from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy
 from lerobot.common.policies.utils import get_device_from_parameters
 from lerobot.common.utils.io_utils import write_video
 from lerobot.common.utils.random_utils import set_seed
@@ -152,7 +153,7 @@ def rollout(
             all_observations.append(deepcopy(observation))
 
         observation = {
-            key: observation[key].to(device, non_blocking=device.type == "cuda") for key in observation
+            key: observation[key].to(device, non_blocking=device.type != "cuda") for key in observation
         }
 
         # Infer "task" from attributes of environments.

--- a/lerobot/scripts/eval.py
+++ b/lerobot/scripts/eval.py
@@ -153,7 +153,7 @@ def rollout(
             all_observations.append(deepcopy(observation))
 
         observation = {
-            key: observation[key].to(device, non_blocking=device.type != "cuda") for key in observation
+            key: observation[key].to(device, non_blocking=device.type != "cpu") for key in observation
         }
 
         # Infer "task" from attributes of environments.

--- a/lerobot/scripts/openloop_eval.py
+++ b/lerobot/scripts/openloop_eval.py
@@ -1,0 +1,180 @@
+from contextlib import nullcontext
+from pprint import pformat
+from termcolor import colored
+import dataclasses
+import logging
+from typing import Iterator
+
+import wandb
+import numpy as np
+import torch
+
+import lerobot.common.datasets.lerobot_dataset as lerobot_dataset
+from lerobot.common.datasets.factory import make_dataset
+from lerobot.common.datasets.utils import cycle
+from lerobot.common.policies.factory import make_policy
+from lerobot.common.utils.utils import (
+    init_logging,
+    get_safe_torch_device,
+)
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.configs import parser
+from lerobot.configs.train import TrainPipelineConfig
+
+class EpisodeSampler(torch.utils.data.Sampler):
+    def __init__(self, dataset: lerobot_dataset.LeRobotDataset, episode_index: int):
+        from_idx = dataset.episode_data_index["from"][episode_index].item()
+        to_idx = dataset.episode_data_index["to"][episode_index].item()
+        self.frame_ids = range(from_idx, to_idx)
+
+    def __iter__(self) -> Iterator:
+        return iter(self.frame_ids)
+
+    def __len__(self) -> int:
+        return len(self.frame_ids)
+
+@parser.wrap()
+def main(cfg: TrainPipelineConfig):
+    init_logging()
+    logging.info(pformat(dataclasses.asdict(cfg)))
+
+    device = get_safe_torch_device(cfg.policy.device, log=True)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+    set_seed(cfg.seed)
+
+    wandb.init(
+        name=cfg.job_name,
+        config=dataclasses.asdict(cfg),
+        project="lerobot",
+    )
+    
+    logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
+
+    logging.info("Making dataset.")
+    dataset = make_dataset(cfg)
+    dataset.meta.info['features']['observation.state']['shape'] = (13,)
+    dataset.meta.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
+                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum']
+    dataset.meta.info['features']['action']['shape'] = (13,)
+    dataset.meta.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
+                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp']
+    
+    for key, episode_stats in dataset.meta.episodes_stats.items():
+                for feature in ['observation.state', 'action']:
+                    for sub_feature in ['min', 'max', 'mean', 'std']:
+                        episode_stats[feature][sub_feature] = np.delete(episode_stats[feature][sub_feature], [6,13], axis=0)
+                        dataset.meta.episodes_stats[key] = episode_stats
+    for feature in ['min', 'max', 'mean', 'std']:
+        dataset.meta.stats['observation.state'][feature] = np.delete(dataset.meta.stats['observation.state'][feature], [6,13], axis=0)
+        dataset.meta.stats['action'][feature] = np.delete(dataset.meta.stats['action'][feature], [6,13], axis=0)
+    
+
+    logging.info("Making policy.")
+    policy = make_policy(
+        cfg=cfg.policy,
+        ds_meta=dataset.meta,
+    )
+    
+    # TODO: 支持多条，从配置读取
+    episode_index = 0
+    
+    sampler = EpisodeSampler(
+        dataset,  episode_index
+    )
+    data_len = len(sampler)
+    print("entire data len:", data_len)
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        num_workers=cfg.num_workers,
+        batch_size=cfg.batch_size,
+        sampler=sampler,
+    )
+    
+    policy.eval()
+    
+    # aloha
+    # dim_names = [
+    #     "arm_left_0", "arm_left_1", "arm_left_2", "arm_left_3", "arm_left_4", "arm_left_5",
+    #     "arm_left_gripper_0", "arm_left_gripper_1",
+    #     "arm_right_0", "arm_right_1", "arm_right_2", "arm_right_3", "arm_right_4", "arm_right_5",
+    #     "arm_right_gripper_0", "arm_right_gripper_1",
+    # ]
+    
+    # galaxea vacumn - 13 dim
+    dim_names = [
+        "arm_left_0", "arm_left_1", "arm_left_2", "arm_left_3", "arm_left_4", "arm_left_5",
+        "arm_right_0", "arm_right_1", "arm_right_2", "arm_right_3", "arm_right_4", "arm_right_5",
+        "arm_right_vacumn",
+    ]
+    # galaxea vacumn - 15 dim
+    # dim_names = [
+    #     "arm_left_0", "arm_left_1", "arm_left_2", "arm_left_3", "arm_left_4", "arm_left_5", "arm_left_gripper",
+    #     "arm_right_0", "arm_right_1", "arm_right_2", "arm_right_3", "arm_right_4", "arm_right_5","arm_right_gripper",
+    #     "arm_right_vacumn",
+    # ]
+    
+    with torch.no_grad(), torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext():
+        # infer_action = policy.forward(input_raw_data)
+        dl_iter = cycle(dataloader)
+        
+        # skip the first few frames
+        for i in range(50):
+            a = next(dl_iter)
+        
+        
+        for step in range(200):
+            # 准备数据
+            input_raw_data = next(dl_iter)
+            
+            # shape记录 galaxea
+            # observation.images.front: torch.Size([batch, 3, 360, 640])
+            # observation.images.wrist_right: torch.Size([batch, 3, 480, 640])
+            # observation.state torch.Size([batch, 15])
+            if 'observation.images.depth' in input_raw_data:
+                del input_raw_data['observation.images.depth']
+                
+            if input_raw_data["observation.state"].shape[-1] == 15:
+                keep_cols = [i for i in range(15) if i not in {6, 13}]
+                # 切片操作删除指定列
+                input_raw_data["observation.state"] = input_raw_data["observation.state"][..., keep_cols]
+                print("state shape", input_raw_data["observation.state"].shape)
+                
+            if input_raw_data["action"].shape[-1] == 15:
+                keep_cols = [i for i in range(15) if i not in {6, 13}]
+                input_raw_data["action"] = input_raw_data["action"][..., keep_cols]
+                print("action shape", input_raw_data["action"].shape)
+            
+            for key in input_raw_data:
+                if isinstance(input_raw_data[key], torch.Tensor):
+                    input_raw_data[key] = input_raw_data[key].to(device, non_blocking=True)
+                    
+            # the front camera resolution is 640x360, pad it to 640x480 which is the resolution of the wrist camera
+            input_raw_data['observation.images.front'] = torch.nn.functional.pad(
+                input_raw_data['observation.images.front'], 
+                pad=(0, 0, 60, 60),  # 左右不填充，上下各填充60
+                mode='constant', 
+                value=0  # black
+            )
+            logging.warning("pad the front images to ", input_raw_data['observation.images.front'].shape)
+            
+            # 推理
+            infer_action = policy.select_action(input_raw_data)
+            infer_action = infer_action[0].cpu().numpy()
+            
+            
+            origin_action = input_raw_data["action"].cpu().numpy()[0][0]
+            
+            # 记录每个action dim的差异
+            diff = infer_action - origin_action
+            log_dict = {}
+            for dim in range(cfg.policy.output_features["action"].shape[0]):
+                key = f"{dim_names[dim]}_diff"
+                log_dict[key] = diff[dim]
+            
+            wandb.log(log_dict)
+
+
+if __name__ == "__main__":
+    main()
+

--- a/lerobot/scripts/serving_policy.py
+++ b/lerobot/scripts/serving_policy.py
@@ -1,0 +1,81 @@
+import dataclasses
+import enum
+import logging
+import socket
+import tyro
+
+import torch
+
+from lerobot.common.utils.utils import (
+    init_logging,
+    get_safe_torch_device,
+)
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.configs import parser
+from lerobot.configs.eval import EvalPipelineConfig
+from lerobot.common.serving.websocket_policy_server import WebsocketPolicyServer
+from lerobot.common.policies.act.modeling_act import ACTPolicy
+from lerobot.common.policies.diffusion.modeling_diffusion import DiffusionPolicy
+
+
+class PolicyType(enum.Enum):
+    """Supported environments."""
+
+    ACT = "act"
+    DIFFUSION = "diffusion"
+    PI0 = "pi0"
+
+@dataclasses.dataclass
+class Checkpoint:
+    """Load a policy from a trained checkpoint."""
+
+    # Checkpoint directory (e.g., "outputs/train/act_move_reel_0322_nodepth/checkpoints/040000/pretrained_mode").
+    path: str
+    
+    # policy type
+    type: str
+
+@dataclasses.dataclass
+class Args:
+    """Arguments for the serve_policy script."""
+    # If provided, will be used in case the "prompt" key is not present in the data, or if the model doesn't have a default
+    # prompt.
+    default_prompt: str | None = None
+
+    # Port to serve the policy on.
+    port: int = 8000
+    # Record the policy's behavior for debugging.
+    record: bool = False
+
+    # Specifies how to load the policy. If not provided, the default policy for the environment will be used.
+    policy: Checkpoint = dataclasses.field(default_factory=Checkpoint)
+
+def main(args: Args) -> None:
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+    set_seed(1000)
+    
+    print(args)
+    
+    # policy has been in device and evaluated
+    if args.policy.type == PolicyType.ACT.value:
+        policy = ACTPolicy.from_pretrained(args.policy.path)
+    elif args.policy.type == PolicyType.DIFFUSION.value:
+        policy = DiffusionPolicy.from_pretrained(args.policy.path)
+    
+    # Record the policy's behavior.
+    # if args.record:
+    #     policy = _policy.PolicyRecorder(policy, "policy_records")
+
+    server = WebsocketPolicyServer(
+        policy=policy,
+        host="0.0.0.0",
+        port=args.port,
+        metadata={},
+    )
+    server.serve_forever()
+
+
+if __name__ == "__main__":
+    init_logging()
+    main(tyro.cli(Args))

--- a/lerobot/scripts/serving_policy.py
+++ b/lerobot/scripts/serving_policy.py
@@ -8,8 +8,10 @@ import json
 
 import wandb
 import torch
+
 if "ASCEND_HOME_PATH" in os.environ:
     import torch_npu
+
     logging.info("exists npu, import torch_npu")
 
 from lerobot.common.utils.utils import init_logging
@@ -22,7 +24,6 @@ from lerobot.common.policies.diffusion.modeling_diffusion import DiffusionPolicy
 from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy
 
 
-
 class PolicyType(enum.Enum):
     """Supported environments."""
 
@@ -30,31 +31,34 @@ class PolicyType(enum.Enum):
     DIFFUSION = "diffusion"
     PI0 = "pi0"
 
+
 @dataclasses.dataclass
 class Checkpoint:
     """Load a policy from a trained checkpoint."""
 
     # Checkpoint directory (e.g., "outputs/train/act_move_reel_0322_nodepth/checkpoints/040000/pretrained_mode").
     path: str
-    
+
     # policy type
     type: str
-    
+
+
 @dataclasses.dataclass
 class Wandb:
     """WanDB config."""
 
     enable: bool = False
-    
+
     # drop the first frame in order to reduce cold-start influence
     drop_first_n_frames: int = 1
+
 
 @dataclasses.dataclass
 class Trace:
     """Tracing config."""
 
     enable: bool = False
-    
+
     # drop the first frame in order to reduce cold-start influence
     drop_first_n_frames: int = 1
 
@@ -73,18 +77,19 @@ class Args:
 
     # Specifies how to load the policy. If not provided, the default policy for the environment will be used.
     policy: Checkpoint = dataclasses.field(default_factory=Checkpoint)
-    
-    wandb : Wandb = dataclasses.field(default_factory=Wandb)
-    
-    trace : Trace = dataclasses.field(default_factory=Trace)
+
+    wandb: Wandb = dataclasses.field(default_factory=Wandb)
+
+    trace: Trace = dataclasses.field(default_factory=Trace)
+
 
 def main(args: Args) -> None:
     torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
     set_seed(1000)
-    
+
     logging.info(args)
-    
+
     # policy has been in device and evaluated
     if args.policy.type == PolicyType.ACT.value:
         policy = ACTPolicy.from_pretrained(args.policy.path)
@@ -92,10 +97,10 @@ def main(args: Args) -> None:
         policy = DiffusionPolicy.from_pretrained(args.policy.path)
     elif args.policy.type == PolicyType.PI0.value:
         policy = PI0Policy.from_pretrained(args.policy.path)
-        
+
     if args.wandb.enable and args.trace.enable:
         logging.warning("enable pref and profiling at the same time, perf data will be influenced!")
-    
+
     if args.wandb.enable:
         tags = [args.policy.type]
         config = dataclasses.asdict(policy.config)
@@ -112,14 +117,12 @@ def main(args: Args) -> None:
             config.update({"hardware_platform": torch_npu.npu.get_device_name(torch_npu.npu.current_device())})
             tags.append('npu')
 
-        wandb.init(project="model-inference-monitoring", 
-              config=config,
-              tags=tags)
-        
+        wandb.init(project="model-inference-monitoring",
+                   config=config,
+                   tags=tags)
+
         wandb.define_metric("infer_cost_ms", summary="min,max,mean")
-        
-    
-                      
+
     # Record the policy's behavior.
     # if args.record:
     #     policy = _policy.PolicyRecorder(policy, "policy_records")

--- a/lerobot/scripts/serving_policy.py
+++ b/lerobot/scripts/serving_policy.py
@@ -16,6 +16,8 @@ from lerobot.configs.eval import EvalPipelineConfig
 from lerobot.common.serving.websocket_policy_server import WebsocketPolicyServer
 from lerobot.common.policies.act.modeling_act import ACTPolicy
 from lerobot.common.policies.diffusion.modeling_diffusion import DiffusionPolicy
+from lerobot.common.policies.pi0.modeling_pi0 import PI0Policy
+
 
 
 class PolicyType(enum.Enum):
@@ -62,6 +64,8 @@ def main(args: Args) -> None:
         policy = ACTPolicy.from_pretrained(args.policy.path)
     elif args.policy.type == PolicyType.DIFFUSION.value:
         policy = DiffusionPolicy.from_pretrained(args.policy.path)
+    elif args.policy.type == PolicyType.PI0.value:
+        policy = PI0Policy.from_pretrained(args.policy.path)
     
     # Record the policy's behavior.
     # if args.record:

--- a/lerobot/scripts/serving_policy.py
+++ b/lerobot/scripts/serving_policy.py
@@ -50,6 +50,16 @@ class Wandb:
     drop_first_n_frames: int = 1
 
 @dataclasses.dataclass
+class Trace:
+    """Tracing config."""
+
+    enable: bool = False
+    
+    # drop the first frame in order to reduce cold-start influence
+    drop_first_n_frames: int = 1
+
+
+@dataclasses.dataclass
 class Args:
     """Arguments for the serve_policy script."""
     # If provided, will be used in case the "prompt" key is not present in the data, or if the model doesn't have a default
@@ -65,13 +75,15 @@ class Args:
     policy: Checkpoint = dataclasses.field(default_factory=Checkpoint)
     
     wandb : Wandb = dataclasses.field(default_factory=Wandb)
+    
+    trace : Trace = dataclasses.field(default_factory=Trace)
 
 def main(args: Args) -> None:
     torch.backends.cudnn.benchmark = True
     torch.backends.cuda.matmul.allow_tf32 = True
     set_seed(1000)
     
-    print(args)
+    logging.info(args)
     
     # policy has been in device and evaluated
     if args.policy.type == PolicyType.ACT.value:
@@ -80,6 +92,9 @@ def main(args: Args) -> None:
         policy = DiffusionPolicy.from_pretrained(args.policy.path)
     elif args.policy.type == PolicyType.PI0.value:
         policy = PI0Policy.from_pretrained(args.policy.path)
+        
+    if args.wandb.enable and args.trace.enable:
+        logging.warning("enable pref and profiling at the same time, perf data will be influenced!")
     
     if args.wandb.enable:
         tags = [args.policy.type]
@@ -101,10 +116,9 @@ def main(args: Args) -> None:
               config=config,
               tags=tags)
         
-        
         wandb.define_metric("infer_cost_ms", summary="min,max,mean")
-
         
+    
                       
     # Record the policy's behavior.
     # if args.record:
@@ -114,7 +128,11 @@ def main(args: Args) -> None:
         policy=policy,
         host="0.0.0.0",
         port=args.port,
-        metadata={'wandb_enable': args.wandb.enable, 'drop_first_n_frames': args.wandb.drop_first_n_frames},
+        metadata={
+            'wandb_enable': args.wandb.enable,
+            'drop_first_n_frames': args.wandb.drop_first_n_frames,
+            'trace_enable': args.trace.enable
+        },
     )
     server.serve_forever()
 

--- a/lerobot/scripts/serving_policy.py
+++ b/lerobot/scripts/serving_policy.py
@@ -3,13 +3,16 @@ import enum
 import logging
 import socket
 import tyro
+import os
+import json
 
+import wandb
 import torch
+if "ASCEND_HOME_PATH" in os.environ:
+    import torch_npu
+    logging.info("exists npu, import torch_npu")
 
-from lerobot.common.utils.utils import (
-    init_logging,
-    get_safe_torch_device,
-)
+from lerobot.common.utils.utils import init_logging
 from lerobot.common.utils.random_utils import set_seed
 from lerobot.configs import parser
 from lerobot.configs.eval import EvalPipelineConfig
@@ -36,6 +39,15 @@ class Checkpoint:
     
     # policy type
     type: str
+    
+@dataclasses.dataclass
+class Wandb:
+    """WanDB config."""
+
+    enable: bool = False
+    
+    # drop the first frame in order to reduce cold-start influence
+    drop_first_n_frames: int = 1
 
 @dataclasses.dataclass
 class Args:
@@ -51,6 +63,8 @@ class Args:
 
     # Specifies how to load the policy. If not provided, the default policy for the environment will be used.
     policy: Checkpoint = dataclasses.field(default_factory=Checkpoint)
+    
+    wandb : Wandb = dataclasses.field(default_factory=Wandb)
 
 def main(args: Args) -> None:
     torch.backends.cudnn.benchmark = True
@@ -67,6 +81,31 @@ def main(args: Args) -> None:
     elif args.policy.type == PolicyType.PI0.value:
         policy = PI0Policy.from_pretrained(args.policy.path)
     
+    if args.wandb.enable:
+        tags = [args.policy.type]
+        config = dataclasses.asdict(policy.config)
+        if "train_config.json" in os.listdir(args.policy.path):
+            filepath = os.path.join(args.policy.path, "train_config.json")
+            with open(filepath, 'r', encoding='utf-8') as f:
+                data = json.load(f)
+                tags.append(data['dataset']['repo_id'])
+
+        if torch.cuda.is_available():
+            config.update({"hardware_platform": torch.cuda.get_device_name(torch.cuda.current_device())})
+            tags.append('cuda')
+        elif torch_npu.npu.is_available():
+            config.update({"hardware_platform": torch_npu.npu.get_device_name(torch_npu.npu.current_device())})
+            tags.append('npu')
+
+        wandb.init(project="model-inference-monitoring", 
+              config=config,
+              tags=tags)
+        
+        
+        wandb.define_metric("infer_cost_ms", summary="min,max,mean")
+
+        
+                      
     # Record the policy's behavior.
     # if args.record:
     #     policy = _policy.PolicyRecorder(policy, "policy_records")
@@ -75,7 +114,7 @@ def main(args: Args) -> None:
         policy=policy,
         host="0.0.0.0",
         port=args.port,
-        metadata={},
+        metadata={'wandb_enable': args.wandb.enable, 'drop_first_n_frames': args.wandb.drop_first_n_frames},
     )
     server.serve_forever()
 

--- a/lerobot/scripts/shutdown_infer_server.py
+++ b/lerobot/scripts/shutdown_infer_server.py
@@ -1,0 +1,41 @@
+import sys
+import os
+import time
+import websockets.sync.client
+from lerobot.common.utils.msgpack_utils import Packer
+
+def get_try_round(default=60):
+    try:
+        return int(os.environ.get('TRY_ROUND', default))
+    except Exception:
+        return default
+
+host = os.environ.get('INFER_SERVER_HOST')
+port = os.environ.get('INFER_SERVER_PORT')
+if not host or not port:
+    print('[ERROR] INFER_SERVER_HOST or INFER_SERVER_PORT not set')
+    sys.exit(1)
+
+ws_url = f'ws://{host}:{port}/'
+packer = Packer()
+try_round = get_try_round()
+
+for i in range(try_round):
+    try:
+        print(f'[INFO] Attempt {i+1}: Connecting to {ws_url}')
+        ws = websockets.sync.client.connect(ws_url, compression=None, max_size=None)
+        try:
+            ws.send(packer.pack({'command': 'exit'}))
+            ws.recv()
+            print('[SUCCESS] Shutdown command sent successfully.')
+            ws.close()
+            sys.exit(0)
+        except Exception as e:
+            print(f'[ERROR] Failed to send or receive: {e}')
+    except Exception as e:
+        print(f'[WARN] Connection attempt failed: {e}')
+    time.sleep(2)
+
+print(f'[ERROR] Failed to send shutdown command after {try_round} attempts.')
+sys.exit(1)
+

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -19,7 +19,6 @@ from contextlib import nullcontext
 from pprint import pformat
 from typing import Any
 
-import numpy as np
 import torch
 from termcolor import colored
 from torch.amp import GradScaler
@@ -48,7 +47,6 @@ from lerobot.common.utils.utils import (
     has_method,
     init_logging,
 )
-from lerobot.common.utils.image_utils import resize_with_pad_train
 from lerobot.common.utils.wandb_utils import WandBLogger
 from lerobot.configs import parser
 from lerobot.configs.train import TrainPipelineConfig
@@ -128,37 +126,7 @@ def train(cfg: TrainPipelineConfig):
 
     logging.info("Creating dataset")
     dataset = make_dataset(cfg)
-    dataset.meta.info['features']['observation.state']['shape'] = (17,)
-    dataset.meta.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
-                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum',
-                                                               'torso_1', 'torso_2', 'torso_3', 'torso_4']
-    dataset.meta.info['features']['action']['shape'] = (17,)
-    dataset.meta.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
-                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp',
-                                                    'torso_exp_1', 'torso_exp_2', 'torso_exp_3', 'torso_exp_4']
-    
-    dataset.meta.info['features']['observation.images.front']['shape'] = (3, 224, 224)
-    dataset.meta.info['features']['observation.images.wrist_right']['shape'] = (3, 224, 224)
-    
-    if 'observation.images.depth' in dataset.meta.info['features']:
-        del dataset.meta.info['features']['observation.images.depth']
-   
-    for stat_idx in dataset.meta.episodes_stats: 
-        for feature in ['observation.state', 'action']:
-            for sub_feature in ['min', 'max', 'mean', 'std']:
-                dataset.meta.episodes_stats[stat_idx][feature][sub_feature] = np.delete(dataset.meta.episodes_stats[stat_idx][feature][sub_feature], [6,13], axis=0)
-   
-   
-    for stat_idx in dataset.meta.episodes_stats:
-        for feature in ['observation.state', 'action']:
-            for sub_feature in ['min', 'max', 'mean', 'std']:
-                # print('dataset.meta outside', stat_idx, feature, sub_feature)
-                assert dataset.meta.episodes_stats[stat_idx][feature][sub_feature].shape[0] == 17
-    
-    for feature in ['observation.state', 'action']:
-        for sub_feature in ['min', 'max', 'mean', 'std']:
-            dataset.meta.stats[feature][sub_feature] = np.delete(dataset.meta.stats[feature][sub_feature], [6,13], axis=0)
-    
+
     # Create environment used for evaluating checkpoints during training on simulation data.
     # On real-world data, no need to create an environment as evaluations are done outside train.py,
     # using the eval.py instead, with gym_dora environment and dora-rs.
@@ -237,24 +205,11 @@ def train(cfg: TrainPipelineConfig):
         start_time = time.perf_counter()
         batch = next(dl_iter)
         train_tracker.dataloading_s = time.perf_counter() - start_time
-        
-        # remove unused depth info
-        if 'observation.images.depth' in batch:
-            del batch['observation.images.depth']
-            
-        # remove redundant joint states
-        keep_cols = [i for i in range(19) if i not in {6, 13}]
-        # 切片操作删除指定列
-        batch["observation.state"] = batch["observation.state"][..., keep_cols]
-        batch["action"] = batch["action"][..., keep_cols]
-        for obs_key in batch:
-            if 'images' in obs_key:
-                batch[obs_key] = resize_with_pad_train(batch[obs_key], 224, 224)
-        
+
         for key in batch:
             if isinstance(batch[key], torch.Tensor):
                 batch[key] = batch[key].to(device, non_blocking=True)
-        
+
         train_tracker, output_dict = update_policy(
             train_tracker,
             policy,

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -213,6 +213,7 @@ def train(cfg: TrainPipelineConfig):
         shuffle=shuffle,
         sampler=sampler,
         pin_memory=device.type != "cpu",
+        pin_memory_device=device.type,
         drop_last=False,
     )
     dl_iter = cycle(dataloader)

--- a/lerobot/scripts/train.py
+++ b/lerobot/scripts/train.py
@@ -128,27 +128,37 @@ def train(cfg: TrainPipelineConfig):
 
     logging.info("Creating dataset")
     dataset = make_dataset(cfg)
-    dataset.meta.info['features']['observation.state']['shape'] = (13,)
+    dataset.meta.info['features']['observation.state']['shape'] = (17,)
     dataset.meta.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
-                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum']
-    dataset.meta.info['features']['action']['shape'] = (13,)
+                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum',
+                                                               'torso_1', 'torso_2', 'torso_3', 'torso_4']
+    dataset.meta.info['features']['action']['shape'] = (17,)
     dataset.meta.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
-                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp']
+                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp',
+                                                    'torso_exp_1', 'torso_exp_2', 'torso_exp_3', 'torso_exp_4']
     
     dataset.meta.info['features']['observation.images.front']['shape'] = (3, 224, 224)
     dataset.meta.info['features']['observation.images.wrist_right']['shape'] = (3, 224, 224)
     
-    del dataset.meta.info['features']['observation.images.depth']
-    
-    for key, episode_stats in dataset.meta.episodes_stats.items():
-                for feature in ['observation.state', 'action']:
-                    for sub_feature in ['min', 'max', 'mean', 'std']:
-                        episode_stats[feature][sub_feature] = np.delete(episode_stats[feature][sub_feature], [6,13], axis=0)
-                        dataset.meta.episodes_stats[key] = episode_stats
-    for feature in ['min', 'max', 'mean', 'std']:
-        dataset.meta.stats['observation.state'][feature] = np.delete(dataset.meta.stats['observation.state'][feature], [6,13], axis=0)
-        dataset.meta.stats['action'][feature] = np.delete(dataset.meta.stats['action'][feature], [6,13], axis=0)
+    if 'observation.images.depth' in dataset.meta.info['features']:
+        del dataset.meta.info['features']['observation.images.depth']
    
+    for stat_idx in dataset.meta.episodes_stats: 
+        for feature in ['observation.state', 'action']:
+            for sub_feature in ['min', 'max', 'mean', 'std']:
+                dataset.meta.episodes_stats[stat_idx][feature][sub_feature] = np.delete(dataset.meta.episodes_stats[stat_idx][feature][sub_feature], [6,13], axis=0)
+   
+   
+    for stat_idx in dataset.meta.episodes_stats:
+        for feature in ['observation.state', 'action']:
+            for sub_feature in ['min', 'max', 'mean', 'std']:
+                # print('dataset.meta outside', stat_idx, feature, sub_feature)
+                assert dataset.meta.episodes_stats[stat_idx][feature][sub_feature].shape[0] == 17
+    
+    for feature in ['observation.state', 'action']:
+        for sub_feature in ['min', 'max', 'mean', 'std']:
+            dataset.meta.stats[feature][sub_feature] = np.delete(dataset.meta.stats[feature][sub_feature], [6,13], axis=0)
+    
     # Create environment used for evaluating checkpoints during training on simulation data.
     # On real-world data, no need to create an environment as evaluations are done outside train.py,
     # using the eval.py instead, with gym_dora environment and dora-rs.
@@ -232,16 +242,10 @@ def train(cfg: TrainPipelineConfig):
             del batch['observation.images.depth']
             
         # remove redundant joint states
-        if batch["observation.state"].shape[-1] == 15:
-            keep_cols = [i for i in range(15) if i not in {6, 13}]
-            # 切片操作删除指定列
-            batch["observation.state"] = batch["observation.state"][..., keep_cols]
-        
-        # remove redundant joint states
-        if batch["action"].shape[-1] == 15:
-            keep_cols = [i for i in range(15) if i not in {6, 13}]
-            batch["action"] = batch["action"][..., keep_cols]
-        
+        keep_cols = [i for i in range(19) if i not in {6, 13}]
+        # 切片操作删除指定列
+        batch["observation.state"] = batch["observation.state"][..., keep_cols]
+        batch["action"] = batch["action"][..., keep_cols]
         for obs_key in batch:
             if 'images' in obs_key:
                 batch[obs_key] = resize_with_pad_train(batch[obs_key], 224, 224)
@@ -249,7 +253,6 @@ def train(cfg: TrainPipelineConfig):
         for key in batch:
             if isinstance(batch[key], torch.Tensor):
                 batch[key] = batch[key].to(device, non_blocking=True)
-        
         
         train_tracker, output_dict = update_policy(
             train_tracker,

--- a/lerobot/scripts/train_accelerate_npu.py
+++ b/lerobot/scripts/train_accelerate_npu.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import time
+from pprint import pformat
+from typing import Any
+
+
+import torch
+from accelerate import Accelerator
+from accelerate.utils import set_seed as accelerate_set_seed
+from termcolor import colored
+from torch.optim import Optimizer
+
+from lerobot.common.datasets.factory import make_dataset
+from lerobot.common.datasets.sampler import EpisodeAwareSampler
+from lerobot.common.envs.factory import make_env
+from lerobot.common.optim.factory import make_optimizer_and_scheduler
+from lerobot.common.policies.factory import make_policy
+from lerobot.common.policies.pretrained import PreTrainedPolicy
+from lerobot.common.utils.logging_utils import AverageMeter, MetricsTracker
+from lerobot.common.utils.train_utils import (
+    get_step_checkpoint_dir,
+    get_step_identifier,
+    load_training_state,
+    save_checkpoint,
+    update_last_checkpoint,
+)
+from lerobot.common.utils.utils import (
+    format_big_number,
+    has_method,
+    init_logging,
+)
+from lerobot.configs import parser
+from lerobot.configs.train import TrainPipelineConfig
+from lerobot.scripts.eval import eval_policy
+
+
+def update_policy(
+    train_metrics: MetricsTracker,
+    policy: PreTrainedPolicy,
+    batch: Any,
+    optimizer: Optimizer,
+    grad_clip_norm: float,
+    accelerator: Accelerator,
+    lr_scheduler=None,
+) -> tuple[MetricsTracker, dict]:
+    start_time = time.perf_counter()
+    policy.train()
+
+    # Use accelerator's autocast context if mixed precision is enabled
+    with accelerator.autocast():
+        loss, output_dict = policy.forward(batch)
+        # TODO(rcadene): policy.unnormalize_outputs(out_dict)
+
+    # Use accelerator for backward pass
+    accelerator.backward(loss)
+
+    # Gradient clipping - accelerator handles unscaling automatically
+    if accelerator.sync_gradients and grad_clip_norm > 0:
+        grad_norm = accelerator.clip_grad_norm_(policy.parameters(), grad_clip_norm)
+    else:
+        grad_norm = torch.tensor(0.0)
+
+    optimizer.step()
+    lr_scheduler.step() if lr_scheduler is not None else None
+    optimizer.zero_grad()
+
+    # Update policy-specific buffers if needed
+    if has_method(policy, "update"):
+        policy.update()
+
+    # Gather metrics across all processes
+    gatherd_loss = accelerator.gather(loss.detach())
+    gathered_grad_norm = accelerator.gather(grad_norm)
+    # if accelerator.is_main_process:
+    #     logging.info(f"gathered loss: {gatherd_loss}")
+    #     logging.info(f"gathered grad norm: {gathered_grad_norm}")
+
+    loss_value = gatherd_loss.mean().item()
+    grad_norm_value = gathered_grad_norm.mean().item()
+
+    train_metrics.loss = loss_value
+    train_metrics.grad_norm = grad_norm_value
+    train_metrics.lr = optimizer.param_groups[0]["lr"]
+    train_metrics.update_s = time.perf_counter() - start_time
+    return train_metrics, output_dict
+
+
+@parser.wrap()
+def train(cfg: TrainPipelineConfig):
+    cfg.validate()
+    logging.info(pformat(cfg.to_dict()))
+
+    # Initialize accelerator
+    from accelerate.utils import DistributedDataParallelKwargs
+
+    from lerobot.common.utils.wandb_utils import cfg_to_group, get_wandb_run_id_from_filesystem
+
+    ddp_kwargs = DistributedDataParallelKwargs(find_unused_parameters=True)
+    accelerator = Accelerator(
+        mixed_precision="fp16" if cfg.policy.use_amp else "no",
+        gradient_accumulation_steps=1,
+        log_with="wandb" if cfg.wandb.enable else None,
+        kwargs_handlers=[ddp_kwargs],
+        project_dir=cfg.output_dir,
+    )
+
+    accelerator.init_trackers(
+        project_name=cfg.wandb.project+'_npu',
+        init_kwargs={
+            "wandb": {
+                "entity": cfg.wandb.entity,
+                "name": cfg.job_name + '_acclerate',
+                "notes": cfg.wandb.notes,
+                "tags": cfg_to_group(cfg, return_list=True),
+                "dir": cfg.output_dir,
+                "config": cfg.to_dict(),
+                "save_code": False,
+                "job_type": "train_eval",
+                "mode": cfg.wandb.mode if cfg.wandb.mode in ["online", "offline", "disabled"] else "online",
+                "resume": "must" if cfg.resume else None,
+                "id": cfg.wandb.run_id
+                if cfg.wandb.run_id
+                else (get_wandb_run_id_from_filesystem(cfg.output_dir) if cfg.resume else None),
+            }
+        },
+    )
+
+    # Set seed for reproducibility
+    if cfg.seed is not None:
+        accelerate_set_seed(cfg.seed)
+
+    # Setup device - accelerator handles device placement
+    # device = get_safe_torch_device(cfg.policy.device, log=True)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    # Create dataset
+    if accelerator.is_main_process:
+        logging.info("Creating dataset")
+    dataset = make_dataset(cfg)
+
+    # Create evaluation environment (only on main process)
+    eval_env = None
+    if cfg.eval_freq > 0 and cfg.env is not None and accelerator.is_main_process:
+        logging.info("Creating env")
+        eval_env = make_env(cfg.env, n_envs=cfg.eval.batch_size, use_async_envs=cfg.eval.use_async_envs)
+
+    # Create policy
+    if accelerator.is_main_process:
+        logging.info("Creating policy")
+
+    # Use accelerator's device instead of cfg.policy.device
+    with accelerator.main_process_first():
+        policy = make_policy(
+            cfg=cfg.policy,
+            ds_meta=dataset.meta,
+        )
+
+    # Create optimizer and scheduler
+    if accelerator.is_main_process:
+        logging.info("Creating optimizer and scheduler")
+    optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
+
+    step = 0  # number of policy updates
+
+    if cfg.resume:
+        step, optimizer, lr_scheduler = load_training_state(cfg.checkpoint_path, optimizer, lr_scheduler)
+
+    # Prepare dataloader
+    if hasattr(cfg.policy, "drop_n_last_frames"):
+        shuffle = False
+        sampler = EpisodeAwareSampler(
+            dataset.episode_data_index,
+            drop_n_last_frames=cfg.policy.drop_n_last_frames,
+            shuffle=True,
+        )
+    else:
+        shuffle = True
+        sampler = None
+
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        num_workers=cfg.num_workers,
+        batch_size=cfg.batch_size,
+        shuffle=shuffle,
+        sampler=sampler,
+        pin_memory=True,
+        pin_memory_device=cfg.policy.device,
+        drop_last=True,  # Important for distributed training
+    )
+
+    # Prepare for distributed training
+    policy, optimizer, dataloader, lr_scheduler = accelerator.prepare(
+        policy, optimizer, dataloader, lr_scheduler
+    )
+
+    # Log training info (only on main process)
+    if accelerator.is_main_process:
+        num_learnable_params = sum(p.numel() for p in policy.parameters() if p.requires_grad)
+        num_total_params = sum(p.numel() for p in policy.parameters())
+
+        logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
+        if cfg.env is not None:
+            logging.info(f"{cfg.env.task=}")
+        logging.info(f"{cfg.steps=} ({format_big_number(cfg.steps)})")
+        logging.info(f"{dataset.num_frames=} ({format_big_number(dataset.num_frames)})")
+        logging.info(f"{dataset.num_episodes=}")
+        logging.info(f"{num_learnable_params=} ({format_big_number(num_learnable_params)})")
+        logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
+        logging.info(f"Number of processes: {accelerator.num_processes}")
+        logging.info(f"Mixed precision: {accelerator.mixed_precision}")
+    logging.info(f"Device: {accelerator.device}")
+
+    # Create metrics trackers
+    train_metrics = {
+        "loss": AverageMeter("loss", ":.3f"),
+        "grad_norm": AverageMeter("grdn", ":.3f"),
+        "lr": AverageMeter("lr", ":0.1e"),
+        "update_s": AverageMeter("updt_s", ":.3f"),
+        "dataloading_s": AverageMeter("data_s", ":.3f"),
+        "data2device_s": AverageMeter("data2device_s", ":.3f"),
+    }
+
+    train_tracker = MetricsTracker(
+        cfg.batch_size * accelerator.num_processes,  # Account for all processes
+        dataset.num_frames,
+        dataset.num_episodes,
+        train_metrics,
+        initial_step=step,
+    )
+
+    # Training loop
+    policy.train()
+    if accelerator.is_main_process:
+        logging.info("Start offline training on a fixed dataset")
+
+    # Create iterator from dataloader
+    dl_iter = iter(dataloader)
+
+    for current_step in range(step, cfg.steps):
+        start_time = time.perf_counter()
+
+        # Get next batch, cycling through dataloader if needed
+        try:
+            batch = next(dl_iter)
+        except StopIteration:
+            dl_iter = iter(dataloader)
+            batch = next(dl_iter)
+
+        train_tracker.dataloading_s = time.perf_counter() - start_time
+
+        # Update policy
+        train_tracker, output_dict = update_policy(
+            train_tracker,
+            policy,
+            batch,
+            optimizer,
+            cfg.optimizer.grad_clip_norm,
+            accelerator,
+            lr_scheduler=lr_scheduler,
+        )
+
+        # Increment step counter
+        step += 1
+        train_tracker.step()
+
+        # Determine if we should log, save, or evaluate
+        is_log_step = cfg.log_freq > 0 and step % cfg.log_freq == 0
+        is_saving_step = step % cfg.save_freq == 0 or step == cfg.steps
+        is_eval_step = cfg.eval_freq > 0 and step % cfg.eval_freq == 0
+
+        # Logging (only on main process)
+        if is_log_step and accelerator.is_main_process:
+            logging.info(str(accelerator.device) + " : " + str(train_tracker))
+            wandb_log_dict = train_tracker.to_dict()
+            if output_dict:
+                wandb_log_dict.update(output_dict)
+            for k, v in wandb_log_dict.items():
+                accelerator.log({f"{'train'}/{k}": v}, step=step)
+            train_tracker.reset_averages()
+
+        # Checkpointing (only on main process)
+        if cfg.save_checkpoint and is_saving_step:
+            accelerator.wait_for_everyone()
+
+            if accelerator.is_main_process:
+                logging.info(f"Checkpoint policy after step {step}")
+                checkpoint_dir = get_step_checkpoint_dir(cfg.output_dir, cfg.steps, step)
+
+                # Wait for all processes before saving
+
+                # Unwrap model for saving
+                unwrapped_policy = accelerator.unwrap_model(policy)
+                save_checkpoint(checkpoint_dir, step, cfg, unwrapped_policy, optimizer, lr_scheduler)
+                update_last_checkpoint(checkpoint_dir)
+            # if wandb_logger:
+            #     wandb_logger.log_policy(checkpoint_dir)
+    logging.info("=== {accelerator.device} reaches barrier before step {step}")
+    # Wait for all processes to finish
+    accelerator.wait_for_everyone()
+    # if accelerator.is_main_process:
+    #     logging.info("=== one step sync ===")
+
+    # Cleanup
+    if eval_env and accelerator.is_main_process:
+        eval_env.close()
+
+    if accelerator.is_main_process:
+        logging.info("End of training")
+
+
+if __name__ == "__main__":
+    init_logging()
+    train()

--- a/lerobot/scripts/train_multiprocessing.py
+++ b/lerobot/scripts/train_multiprocessing.py
@@ -236,6 +236,7 @@ def train(cfg: TrainPipelineConfig):
     logging.info("Start offline training on a fixed dataset")
     for _ in range(step, cfg.steps):
         start_time = time.perf_counter()
+        sampler.set_epoch(_)
         batch = next(dl_iter)
         train_tracker.dataloading_s = time.perf_counter() - start_time
         

--- a/lerobot/scripts/train_multiprocessing.py
+++ b/lerobot/scripts/train_multiprocessing.py
@@ -213,6 +213,7 @@ def train(cfg: TrainPipelineConfig):
         # shuffle=shuffle,
         sampler=sampler,
         pin_memory=device.type != "cpu",
+        pin_memory_device=device.type,
         drop_last=False,
     )
     dl_iter = cycle(dataloader)

--- a/lerobot/scripts/train_multiprocessing.py
+++ b/lerobot/scripts/train_multiprocessing.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+import logging
+import time
+from contextlib import nullcontext
+from pprint import pformat
+from typing import Any
+
+import numpy as np
+import torch
+import torch_npu
+from termcolor import colored
+from torch.amp import GradScaler
+import torch.distributed
+from torch.optim import Optimizer
+import torch.utils
+import torch.utils.data
+import torch.utils.data.distributed
+import torch_npu.npu
+
+from lerobot.common.datasets.factory import make_dataset
+from lerobot.common.datasets.sampler import EpisodeAwareSampler
+from lerobot.common.datasets.utils import cycle
+from lerobot.common.envs.factory import make_env
+from lerobot.common.optim.factory import make_optimizer_and_scheduler
+from lerobot.common.policies.factory import make_policy
+from lerobot.common.policies.pretrained import PreTrainedPolicy
+from lerobot.common.policies.utils import get_device_from_parameters
+from lerobot.common.utils.logging_utils import AverageMeter, MetricsTracker
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.common.utils.train_utils import (
+    get_step_checkpoint_dir,
+    get_step_identifier,
+    load_training_state,
+    save_checkpoint,
+    update_last_checkpoint,
+)
+from lerobot.common.utils.utils import (
+    format_big_number,
+    get_safe_torch_device,
+    has_method,
+    init_logging,
+)
+from lerobot.common.utils.image_utils import resize_with_pad_train
+from lerobot.common.utils.wandb_utils import WandBLogger
+from lerobot.configs import parser
+from lerobot.configs.train import TrainPipelineConfig
+from lerobot.scripts.eval import eval_policy
+
+
+def update_policy(
+    train_metrics: MetricsTracker,
+    policy: PreTrainedPolicy,
+    batch: Any,
+    optimizer: Optimizer,
+    grad_clip_norm: float,
+    grad_scaler: GradScaler,
+    lr_scheduler=None,
+    use_amp: bool = False,
+    lock=None,
+) -> tuple[MetricsTracker, dict]:
+    start_time = time.perf_counter()
+    device = get_device_from_parameters(policy)
+    policy.train()
+    with torch.autocast(device_type=device.type) if use_amp else nullcontext():
+        loss, output_dict = policy.forward(batch)
+        # TODO(rcadene): policy.unnormalize_outputs(out_dict)
+        # print("=== loss:", loss)
+    grad_scaler.scale(loss).backward()
+
+    # Unscale the gradient of the optimizer's assigned params in-place **prior to gradient clipping**.
+    grad_scaler.unscale_(optimizer)
+
+    grad_norm = torch.nn.utils.clip_grad_norm_(
+        policy.parameters(),
+        grad_clip_norm,
+        error_if_nonfinite=False,
+    )
+
+    # Optimizer's gradients are already unscaled, so scaler.step does not unscale them,
+    # although it still skips optimizer.step() if the gradients contain infs or NaNs.
+    with lock if lock is not None else nullcontext():
+        grad_scaler.step(optimizer)
+    # Updates the scale for next iteration.
+    grad_scaler.update()
+
+    optimizer.zero_grad()
+
+    # Step through pytorch scheduler at every batch instead of epoch
+    if lr_scheduler is not None:
+        lr_scheduler.step()
+
+    if has_method(policy, "update"):
+        # To possibly update an internal buffer (for instance an Exponential Moving Average like in TDMPC).
+        policy.update()
+
+    train_metrics.loss = loss.item()
+    train_metrics.grad_norm = grad_norm.item()
+    train_metrics.lr = optimizer.param_groups[0]["lr"]
+    train_metrics.update_s = time.perf_counter() - start_time
+    return train_metrics, output_dict
+
+
+@parser.wrap()
+def train(cfg: TrainPipelineConfig):
+    local_rank = int(os.environ["LOCAL_RANK"])
+    world_size = int(os.environ["WORLD_SIZE"])
+
+    cfg.validate()
+    if local_rank == 0:
+        logging.info(pformat(cfg.to_dict()))
+
+    if cfg.wandb.enable and cfg.wandb.project:
+        wandb_logger = WandBLogger(cfg)
+    else:
+        wandb_logger = None
+        logging.info(colored("Logs will be saved locally.", "yellow", attrs=["bold"]))
+
+    if cfg.seed is not None:
+        set_seed(cfg.seed)
+
+    # Check device is available
+    # device = get_safe_torch_device(cfg.policy.device, log=True)
+
+    
+    
+    torch_npu.npu.set_device(local_rank)
+    device = torch.device(f"npu:{local_rank}")
+    logging.info(f"launch at device {device} with word size {world_size}")
+
+    torch.distributed.init_process_group(backend="hccl", rank=local_rank, world_size=world_size)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+    if local_rank == 0:
+        logging.info("Creating dataset")
+    dataset = make_dataset(cfg)
+    if local_rank == 0:
+        logging.info("Dataset created")
+    # for feature in dataset.meta.info['features']:
+    #     if "images" in feature:
+    #         dataset.meta.info['features'][feature]['shape'] = (3, 224, 224)
+   
+    # Create environment used for evaluating checkpoints during training on simulation data.
+    # On real-world data, no need to create an environment as evaluations are done outside train.py,
+    # using the eval.py instead, with gym_dora environment and dora-rs.
+    eval_env = None
+    if cfg.eval_freq > 0 and cfg.env is not None:
+        if local_rank == 0:
+            logging.info("Creating env")
+        eval_env = make_env(cfg.env, n_envs=cfg.eval.batch_size, use_async_envs=cfg.eval.use_async_envs)
+    if local_rank == 0:
+        logging.info("Creating policy")
+    policy = make_policy(
+        cfg=cfg.policy,
+        ds_meta=dataset.meta,
+    )
+    if local_rank == 0:
+        logging.info("Creating optimizer and scheduler")
+    optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
+    grad_scaler = GradScaler(device.type, enabled=cfg.policy.use_amp)
+
+    step = 0  # number of policy updates (forward + backward + optim)
+
+    if cfg.resume:
+        step, optimizer, lr_scheduler = load_training_state(cfg.checkpoint_path, optimizer, lr_scheduler)
+
+    num_learnable_params = sum(p.numel() for p in policy.parameters() if p.requires_grad)
+    num_total_params = sum(p.numel() for p in policy.parameters())
+    
+    if local_rank == 0:
+        logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
+    if cfg.env is not None:
+        logging.info(f"{cfg.env.task=}")
+    logging.info(f"{cfg.steps=} ({format_big_number(cfg.steps)})")
+    logging.info(f"{dataset.num_frames=} ({format_big_number(dataset.num_frames)})")
+    logging.info(f"{dataset.num_episodes=}")
+    logging.info(f"{num_learnable_params=} ({format_big_number(num_learnable_params)})")
+    logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
+
+    # create dataloader for offline training
+    # if hasattr(cfg.policy, "drop_n_last_frames"):
+    #     shuffle = False
+    #     sampler = EpisodeAwareSampler(
+    #         dataset.episode_data_index,
+    #         drop_n_last_frames=cfg.policy.drop_n_last_frames,
+    #         shuffle=True,
+    #     )
+    # else:
+    #     shuffle = True
+    #     sampler = None
+
+    shuffle = True
+    sampler = torch.utils.data.distributed.DistributedSampler(dataset=dataset, num_replicas=world_size, rank=local_rank, shuffle=shuffle)
+
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        num_workers=cfg.num_workers,
+        batch_size=cfg.batch_size,
+        # shuffle=shuffle,
+        sampler=sampler,
+        pin_memory=device.type != "cpu",
+        drop_last=False,
+    )
+    dl_iter = cycle(dataloader)
+
+    policy = torch.nn.parallel.DistributedDataParallel(policy, device_ids=[local_rank], output_device=local_rank, find_unused_parameters=True)
+
+    policy.train()
+
+    train_metrics = {
+        "loss": AverageMeter("loss", ":.3f"),
+        "grad_norm": AverageMeter("grdn", ":.3f"),
+        "lr": AverageMeter("lr", ":0.1e"),
+        "update_s": AverageMeter("updt_s", ":.3f"),
+        "dataloading_s": AverageMeter("data_s", ":.3f"),
+    }
+
+    train_tracker = MetricsTracker(
+        cfg.batch_size, dataset.num_frames, dataset.num_episodes, train_metrics, initial_step=step
+    )
+
+    logging.info("Start offline training on a fixed dataset")
+    for _ in range(step, cfg.steps):
+        start_time = time.perf_counter()
+        batch = next(dl_iter)
+        train_tracker.dataloading_s = time.perf_counter() - start_time
+        
+        # for obs_key in batch:
+        #     if 'images' in obs_key:
+        #         if 'is_pad' in obs_key:
+        #             continue
+        #         batch[obs_key] = resize_with_pad_train(batch[obs_key], 224, 224)
+        
+        for key in batch:
+            if isinstance(batch[key], torch.Tensor):
+                batch[key] = batch[key].to(device, non_blocking=True)
+        
+        train_tracker, output_dict = update_policy(
+            train_tracker,
+            policy,
+            batch,
+            optimizer,
+            cfg.optimizer.grad_clip_norm,
+            grad_scaler=grad_scaler,
+            lr_scheduler=lr_scheduler,
+            use_amp=cfg.policy.use_amp,
+        )
+
+        # Note: eval and checkpoint happens *after* the `step`th training update has completed, so we
+        # increment `step` here.
+        step += 1
+        train_tracker.step()
+        is_log_step = cfg.log_freq > 0 and step % cfg.log_freq == 0
+        is_saving_step = step % cfg.save_freq == 0 or step == cfg.steps
+        is_eval_step = cfg.eval_freq > 0 and step % cfg.eval_freq == 0
+
+        if is_log_step:
+            logging.info(train_tracker)
+            if wandb_logger:
+                wandb_log_dict = train_tracker.to_dict()
+                if output_dict:
+                    wandb_log_dict.update(output_dict)
+                wandb_logger.log_dict(wandb_log_dict, step)
+            train_tracker.reset_averages()
+
+        if cfg.save_checkpoint and is_saving_step and local_rank == 0:
+            logging.info(f"Checkpoint policy after step {step}")
+            checkpoint_dir = get_step_checkpoint_dir(cfg.output_dir, cfg.steps, step)
+            save_checkpoint(checkpoint_dir, step, cfg, policy.module, optimizer, lr_scheduler)
+            update_last_checkpoint(checkpoint_dir)
+            # if wandb_logger:
+            #     wandb_logger.log_policy(checkpoint_dir)
+
+        if cfg.env and is_eval_step:
+            step_id = get_step_identifier(step, cfg.steps)
+            logging.info(f"Eval policy at step {step}")
+            with (
+                torch.no_grad(),
+                torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext(),
+            ):
+                eval_info = eval_policy(
+                    eval_env,
+                    policy,
+                    cfg.eval.n_episodes,
+                    videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
+                    max_episodes_rendered=4,
+                    start_seed=cfg.seed,
+                )
+
+            eval_metrics = {
+                "avg_sum_reward": AverageMeter("∑rwrd", ":.3f"),
+                "pc_success": AverageMeter("success", ":.1f"),
+                "eval_s": AverageMeter("eval_s", ":.3f"),
+            }
+            eval_tracker = MetricsTracker(
+                cfg.batch_size, dataset.num_frames, dataset.num_episodes, eval_metrics, initial_step=step
+            )
+            eval_tracker.eval_s = eval_info["aggregated"].pop("eval_s")
+            eval_tracker.avg_sum_reward = eval_info["aggregated"].pop("avg_sum_reward")
+            eval_tracker.pc_success = eval_info["aggregated"].pop("pc_success")
+            logging.info(eval_tracker)
+            if wandb_logger:
+                wandb_log_dict = {**eval_tracker.to_dict(), **eval_info}
+                wandb_logger.log_dict(wandb_log_dict, step, mode="eval")
+                wandb_logger.log_video(eval_info["video_paths"][0], step, mode="eval")
+
+    if eval_env:
+        eval_env.close()
+    logging.info("End of training")
+
+
+if __name__ == "__main__":
+    init_logging()
+    train()

--- a/lerobot/scripts/train_no_pad.py
+++ b/lerobot/scripts/train_no_pad.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import time
+from contextlib import nullcontext
+from pprint import pformat
+from typing import Any
+
+import numpy as np
+import torch
+from termcolor import colored
+from torch.amp import GradScaler
+from torch.optim import Optimizer
+
+from lerobot.common.datasets.factory import make_dataset
+from lerobot.common.datasets.sampler import EpisodeAwareSampler
+from lerobot.common.datasets.utils import cycle
+from lerobot.common.envs.factory import make_env
+from lerobot.common.optim.factory import make_optimizer_and_scheduler
+from lerobot.common.policies.factory import make_policy
+from lerobot.common.policies.pretrained import PreTrainedPolicy
+from lerobot.common.policies.utils import get_device_from_parameters
+from lerobot.common.utils.logging_utils import AverageMeter, MetricsTracker
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.common.utils.train_utils import (
+    get_step_checkpoint_dir,
+    get_step_identifier,
+    load_training_state,
+    save_checkpoint,
+    update_last_checkpoint,
+)
+from lerobot.common.utils.utils import (
+    format_big_number,
+    get_safe_torch_device,
+    has_method,
+    init_logging,
+)
+from lerobot.common.utils.image_utils import resize_with_pad_train
+from lerobot.common.utils.wandb_utils import WandBLogger
+from lerobot.configs import parser
+from lerobot.configs.train import TrainPipelineConfig
+from lerobot.scripts.eval import eval_policy
+
+
+def update_policy(
+    train_metrics: MetricsTracker,
+    policy: PreTrainedPolicy,
+    batch: Any,
+    optimizer: Optimizer,
+    grad_clip_norm: float,
+    grad_scaler: GradScaler,
+    lr_scheduler=None,
+    use_amp: bool = False,
+    lock=None,
+) -> tuple[MetricsTracker, dict]:
+    start_time = time.perf_counter()
+    device = get_device_from_parameters(policy)
+    policy.train()
+    with torch.autocast(device_type=device.type) if use_amp else nullcontext():
+        loss, output_dict = policy.forward(batch)
+        # TODO(rcadene): policy.unnormalize_outputs(out_dict)
+    grad_scaler.scale(loss).backward()
+
+    # Unscale the gradient of the optimizer's assigned params in-place **prior to gradient clipping**.
+    grad_scaler.unscale_(optimizer)
+
+    grad_norm = torch.nn.utils.clip_grad_norm_(
+        policy.parameters(),
+        grad_clip_norm,
+        error_if_nonfinite=False,
+    )
+
+    # Optimizer's gradients are already unscaled, so scaler.step does not unscale them,
+    # although it still skips optimizer.step() if the gradients contain infs or NaNs.
+    with lock if lock is not None else nullcontext():
+        grad_scaler.step(optimizer)
+    # Updates the scale for next iteration.
+    grad_scaler.update()
+
+    optimizer.zero_grad()
+
+    # Step through pytorch scheduler at every batch instead of epoch
+    if lr_scheduler is not None:
+        lr_scheduler.step()
+
+    if has_method(policy, "update"):
+        # To possibly update an internal buffer (for instance an Exponential Moving Average like in TDMPC).
+        policy.update()
+
+    train_metrics.loss = loss.item()
+    train_metrics.grad_norm = grad_norm.item()
+    train_metrics.lr = optimizer.param_groups[0]["lr"]
+    train_metrics.update_s = time.perf_counter() - start_time
+    return train_metrics, output_dict
+
+
+@parser.wrap()
+def train(cfg: TrainPipelineConfig):
+    cfg.validate()
+    logging.info(pformat(cfg.to_dict()))
+
+    if cfg.wandb.enable and cfg.wandb.project:
+        wandb_logger = WandBLogger(cfg)
+    else:
+        wandb_logger = None
+        logging.info(colored("Logs will be saved locally.", "yellow", attrs=["bold"]))
+
+    if cfg.seed is not None:
+        set_seed(cfg.seed)
+
+    # Check device is available
+    device = get_safe_torch_device(cfg.policy.device, log=True)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    logging.info("Creating dataset")
+    dataset = make_dataset(cfg)
+    dataset.meta.info['features']['observation.state']['shape'] = (17,)
+    dataset.meta.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
+                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum',
+                                                               'torso_1', 'torso_2', 'torso_3', 'torso_4']
+    dataset.meta.info['features']['action']['shape'] = (17,)
+    dataset.meta.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
+                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp',
+                                                    'torso_exp_1', 'torso_exp_2', 'torso_exp_3', 'torso_exp_4']
+    
+    if 'observation.images.depth' in dataset.meta.info['features']:
+        del dataset.meta.info['features']['observation.images.depth']
+   
+    for stat_idx in dataset.meta.episodes_stats: 
+        for feature in ['observation.state', 'action']:
+            for sub_feature in ['min', 'max', 'mean', 'std']:
+                dataset.meta.episodes_stats[stat_idx][feature][sub_feature] = np.delete(dataset.meta.episodes_stats[stat_idx][feature][sub_feature], [6,13], axis=0)
+   
+   
+    for stat_idx in dataset.meta.episodes_stats:
+        for feature in ['observation.state', 'action']:
+            for sub_feature in ['min', 'max', 'mean', 'std']:
+                # print('dataset.meta outside', stat_idx, feature, sub_feature)
+                assert dataset.meta.episodes_stats[stat_idx][feature][sub_feature].shape[0] == 17
+    
+    for feature in ['observation.state', 'action']:
+        for sub_feature in ['min', 'max', 'mean', 'std']:
+            dataset.meta.stats[feature][sub_feature] = np.delete(dataset.meta.stats[feature][sub_feature], [6,13], axis=0)
+    
+    # Create environment used for evaluating checkpoints during training on simulation data.
+    # On real-world data, no need to create an environment as evaluations are done outside train.py,
+    # using the eval.py instead, with gym_dora environment and dora-rs.
+    eval_env = None
+    if cfg.eval_freq > 0 and cfg.env is not None:
+        logging.info("Creating env")
+        eval_env = make_env(cfg.env, n_envs=cfg.eval.batch_size, use_async_envs=cfg.eval.use_async_envs)
+
+    logging.info("Creating policy")
+    policy = make_policy(
+        cfg=cfg.policy,
+        ds_meta=dataset.meta,
+    )
+
+    logging.info("Creating optimizer and scheduler")
+    optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
+    grad_scaler = GradScaler(device.type, enabled=cfg.policy.use_amp)
+
+    step = 0  # number of policy updates (forward + backward + optim)
+
+    if cfg.resume:
+        step, optimizer, lr_scheduler = load_training_state(cfg.checkpoint_path, optimizer, lr_scheduler)
+
+    num_learnable_params = sum(p.numel() for p in policy.parameters() if p.requires_grad)
+    num_total_params = sum(p.numel() for p in policy.parameters())
+
+    logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
+    if cfg.env is not None:
+        logging.info(f"{cfg.env.task=}")
+    logging.info(f"{cfg.steps=} ({format_big_number(cfg.steps)})")
+    logging.info(f"{dataset.num_frames=} ({format_big_number(dataset.num_frames)})")
+    logging.info(f"{dataset.num_episodes=}")
+    logging.info(f"{num_learnable_params=} ({format_big_number(num_learnable_params)})")
+    logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
+
+    # create dataloader for offline training
+    if hasattr(cfg.policy, "drop_n_last_frames"):
+        shuffle = False
+        sampler = EpisodeAwareSampler(
+            dataset.episode_data_index,
+            drop_n_last_frames=cfg.policy.drop_n_last_frames,
+            shuffle=True,
+        )
+    else:
+        shuffle = True
+        sampler = None
+
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        num_workers=cfg.num_workers,
+        batch_size=cfg.batch_size,
+        shuffle=shuffle,
+        sampler=sampler,
+        pin_memory=device.type != "cpu",
+        drop_last=False,
+    )
+    dl_iter = cycle(dataloader)
+
+    policy.train()
+
+    train_metrics = {
+        "loss": AverageMeter("loss", ":.3f"),
+        "grad_norm": AverageMeter("grdn", ":.3f"),
+        "lr": AverageMeter("lr", ":0.1e"),
+        "update_s": AverageMeter("updt_s", ":.3f"),
+        "dataloading_s": AverageMeter("data_s", ":.3f"),
+    }
+
+    train_tracker = MetricsTracker(
+        cfg.batch_size, dataset.num_frames, dataset.num_episodes, train_metrics, initial_step=step
+    )
+
+    logging.info("Start offline training on a fixed dataset")
+    for _ in range(step, cfg.steps):
+        start_time = time.perf_counter()
+        batch = next(dl_iter)
+        train_tracker.dataloading_s = time.perf_counter() - start_time
+        
+        # remove unused depth info
+        if 'observation.images.depth' in batch:
+            del batch['observation.images.depth']
+            
+        # remove redundant joint states
+        keep_cols = [i for i in range(19) if i not in {6, 13}]
+        # 切片操作删除指定列
+        batch["observation.state"] = batch["observation.state"][..., keep_cols]
+        batch["action"] = batch["action"][..., keep_cols]
+        # for obs_key in batch:
+        #     if 'images' in obs_key:
+        #         batch[obs_key] = resize_with_pad_train(batch[obs_key], 224, 224)
+        
+        for key in batch:
+            if isinstance(batch[key], torch.Tensor):
+                batch[key] = batch[key].to(device, non_blocking=True)
+        
+        train_tracker, output_dict = update_policy(
+            train_tracker,
+            policy,
+            batch,
+            optimizer,
+            cfg.optimizer.grad_clip_norm,
+            grad_scaler=grad_scaler,
+            lr_scheduler=lr_scheduler,
+            use_amp=cfg.policy.use_amp,
+        )
+
+        # Note: eval and checkpoint happens *after* the `step`th training update has completed, so we
+        # increment `step` here.
+        step += 1
+        train_tracker.step()
+        is_log_step = cfg.log_freq > 0 and step % cfg.log_freq == 0
+        is_saving_step = step % cfg.save_freq == 0 or step == cfg.steps
+        is_eval_step = cfg.eval_freq > 0 and step % cfg.eval_freq == 0
+
+        if is_log_step:
+            logging.info(train_tracker)
+            if wandb_logger:
+                wandb_log_dict = train_tracker.to_dict()
+                if output_dict:
+                    wandb_log_dict.update(output_dict)
+                wandb_logger.log_dict(wandb_log_dict, step)
+            train_tracker.reset_averages()
+
+        if cfg.save_checkpoint and is_saving_step:
+            logging.info(f"Checkpoint policy after step {step}")
+            checkpoint_dir = get_step_checkpoint_dir(cfg.output_dir, cfg.steps, step)
+            save_checkpoint(checkpoint_dir, step, cfg, policy, optimizer, lr_scheduler)
+            update_last_checkpoint(checkpoint_dir)
+            if wandb_logger:
+                wandb_logger.log_policy(checkpoint_dir)
+
+        if cfg.env and is_eval_step:
+            step_id = get_step_identifier(step, cfg.steps)
+            logging.info(f"Eval policy at step {step}")
+            with (
+                torch.no_grad(),
+                torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext(),
+            ):
+                eval_info = eval_policy(
+                    eval_env,
+                    policy,
+                    cfg.eval.n_episodes,
+                    videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
+                    max_episodes_rendered=4,
+                    start_seed=cfg.seed,
+                )
+
+            eval_metrics = {
+                "avg_sum_reward": AverageMeter("∑rwrd", ":.3f"),
+                "pc_success": AverageMeter("success", ":.1f"),
+                "eval_s": AverageMeter("eval_s", ":.3f"),
+            }
+            eval_tracker = MetricsTracker(
+                cfg.batch_size, dataset.num_frames, dataset.num_episodes, eval_metrics, initial_step=step
+            )
+            eval_tracker.eval_s = eval_info["aggregated"].pop("eval_s")
+            eval_tracker.avg_sum_reward = eval_info["aggregated"].pop("avg_sum_reward")
+            eval_tracker.pc_success = eval_info["aggregated"].pop("pc_success")
+            logging.info(eval_tracker)
+            if wandb_logger:
+                wandb_log_dict = {**eval_tracker.to_dict(), **eval_info}
+                wandb_logger.log_dict(wandb_log_dict, step, mode="eval")
+                wandb_logger.log_video(eval_info["video_paths"][0], step, mode="eval")
+
+    if eval_env:
+        eval_env.close()
+    logging.info("End of training")
+
+
+if __name__ == "__main__":
+    init_logging()
+    train()

--- a/lerobot/scripts/train_no_pad.py
+++ b/lerobot/scripts/train_no_pad.py
@@ -210,6 +210,7 @@ def train(cfg: TrainPipelineConfig):
         shuffle=shuffle,
         sampler=sampler,
         pin_memory=device.type != "cpu",
+        pin_memory_device=device.type,
         drop_last=False,
     )
     dl_iter = cycle(dataloader)

--- a/lerobot/scripts/train_robocasa.py
+++ b/lerobot/scripts/train_robocasa.py
@@ -128,26 +128,9 @@ def train(cfg: TrainPipelineConfig):
 
     logging.info("Creating dataset")
     dataset = make_dataset(cfg)
-    dataset.meta.info['features']['observation.state']['shape'] = (13,)
-    dataset.meta.info['features']['observation.state']['names'] = ['left_arm_1', 'left_arm_2', 'left_arm_3', 'left_arm_4', 'left_arm_5', 'left_arm_6', 
-                                                               'right_arm_1', 'right_arm_2', 'right_arm_3', 'right_arm_4', 'right_arm_5', 'right_arm_6', 'vacuum']
-    dataset.meta.info['features']['action']['shape'] = (13,)
-    dataset.meta.info['features']['action']['names'] = ['left_arm_exp_1', 'left_arm_exp_2', 'left_arm_exp_3', 'left_arm_exp_4', 'left_arm_exp_5', 'left_arm_exp_6', 
-                                                    'right_arm_exp_1', 'right_arm_exp_2', 'right_arm_exp_3', 'right_arm_exp_4', 'right_arm_exp_5', 'right_arm_exp_6', 'vacuum_exp']
-    
-    dataset.meta.info['features']['observation.images.front']['shape'] = (3, 224, 224)
-    dataset.meta.info['features']['observation.images.wrist_right']['shape'] = (3, 224, 224)
-    
-    del dataset.meta.info['features']['observation.images.depth']
-    
-    for key, episode_stats in dataset.meta.episodes_stats.items():
-                for feature in ['observation.state', 'action']:
-                    for sub_feature in ['min', 'max', 'mean', 'std']:
-                        episode_stats[feature][sub_feature] = np.delete(episode_stats[feature][sub_feature], [6,13], axis=0)
-                        dataset.meta.episodes_stats[key] = episode_stats
-    for feature in ['min', 'max', 'mean', 'std']:
-        dataset.meta.stats['observation.state'][feature] = np.delete(dataset.meta.stats['observation.state'][feature], [6,13], axis=0)
-        dataset.meta.stats['action'][feature] = np.delete(dataset.meta.stats['action'][feature], [6,13], axis=0)
+    for feature in dataset.meta.info['features']:
+        if "images" in feature:
+            dataset.meta.info['features'][feature]['shape'] = (3, 224, 224)
    
     # Create environment used for evaluating checkpoints during training on simulation data.
     # On real-world data, no need to create an environment as evaluations are done outside train.py,
@@ -227,29 +210,15 @@ def train(cfg: TrainPipelineConfig):
         batch = next(dl_iter)
         train_tracker.dataloading_s = time.perf_counter() - start_time
         
-        # remove unused depth info
-        if 'observation.images.depth' in batch:
-            del batch['observation.images.depth']
-            
-        # remove redundant joint states
-        if batch["observation.state"].shape[-1] == 15:
-            keep_cols = [i for i in range(15) if i not in {6, 13}]
-            # 切片操作删除指定列
-            batch["observation.state"] = batch["observation.state"][..., keep_cols]
-        
-        # remove redundant joint states
-        if batch["action"].shape[-1] == 15:
-            keep_cols = [i for i in range(15) if i not in {6, 13}]
-            batch["action"] = batch["action"][..., keep_cols]
-        
         for obs_key in batch:
             if 'images' in obs_key:
+                if 'is_pad' in obs_key:
+                    continue
                 batch[obs_key] = resize_with_pad_train(batch[obs_key], 224, 224)
         
         for key in batch:
             if isinstance(batch[key], torch.Tensor):
                 batch[key] = batch[key].to(device, non_blocking=True)
-        
         
         train_tracker, output_dict = update_policy(
             train_tracker,

--- a/lerobot/scripts/train_robocasa.py
+++ b/lerobot/scripts/train_robocasa.py
@@ -186,6 +186,7 @@ def train(cfg: TrainPipelineConfig):
         shuffle=shuffle,
         sampler=sampler,
         pin_memory=device.type != "cpu",
+        pin_memory_device=device.type,
         drop_last=False,
     )
     dl_iter = cycle(dataloader)

--- a/lerobot/scripts/train_robocasa_no_pad.py
+++ b/lerobot/scripts/train_robocasa_no_pad.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python
+
+# Copyright 2024 The HuggingFace Inc. team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+import time
+from contextlib import nullcontext
+from pprint import pformat
+from typing import Any
+
+import numpy as np
+import torch
+from termcolor import colored
+from torch.amp import GradScaler
+from torch.optim import Optimizer
+
+from lerobot.common.datasets.factory import make_dataset
+from lerobot.common.datasets.sampler import EpisodeAwareSampler
+from lerobot.common.datasets.utils import cycle
+from lerobot.common.envs.factory import make_env
+from lerobot.common.optim.factory import make_optimizer_and_scheduler
+from lerobot.common.policies.factory import make_policy
+from lerobot.common.policies.pretrained import PreTrainedPolicy
+from lerobot.common.policies.utils import get_device_from_parameters
+from lerobot.common.utils.logging_utils import AverageMeter, MetricsTracker
+from lerobot.common.utils.random_utils import set_seed
+from lerobot.common.utils.train_utils import (
+    get_step_checkpoint_dir,
+    get_step_identifier,
+    load_training_state,
+    save_checkpoint,
+    update_last_checkpoint,
+)
+from lerobot.common.utils.utils import (
+    format_big_number,
+    get_safe_torch_device,
+    has_method,
+    init_logging,
+)
+from lerobot.common.utils.image_utils import resize_with_pad_train
+from lerobot.common.utils.wandb_utils import WandBLogger
+from lerobot.configs import parser
+from lerobot.configs.train import TrainPipelineConfig
+from lerobot.scripts.eval import eval_policy
+
+
+def update_policy(
+    train_metrics: MetricsTracker,
+    policy: PreTrainedPolicy,
+    batch: Any,
+    optimizer: Optimizer,
+    grad_clip_norm: float,
+    grad_scaler: GradScaler,
+    lr_scheduler=None,
+    use_amp: bool = False,
+    lock=None,
+) -> tuple[MetricsTracker, dict]:
+    start_time = time.perf_counter()
+    device = get_device_from_parameters(policy)
+    policy.train()
+    with torch.autocast(device_type=device.type) if use_amp else nullcontext():
+        loss, output_dict = policy.forward(batch)
+        # TODO(rcadene): policy.unnormalize_outputs(out_dict)
+    grad_scaler.scale(loss).backward()
+
+    # Unscale the gradient of the optimizer's assigned params in-place **prior to gradient clipping**.
+    grad_scaler.unscale_(optimizer)
+
+    grad_norm = torch.nn.utils.clip_grad_norm_(
+        policy.parameters(),
+        grad_clip_norm,
+        error_if_nonfinite=False,
+    )
+
+    # Optimizer's gradients are already unscaled, so scaler.step does not unscale them,
+    # although it still skips optimizer.step() if the gradients contain infs or NaNs.
+    with lock if lock is not None else nullcontext():
+        grad_scaler.step(optimizer)
+    # Updates the scale for next iteration.
+    grad_scaler.update()
+
+    optimizer.zero_grad()
+
+    # Step through pytorch scheduler at every batch instead of epoch
+    if lr_scheduler is not None:
+        lr_scheduler.step()
+
+    if has_method(policy, "update"):
+        # To possibly update an internal buffer (for instance an Exponential Moving Average like in TDMPC).
+        policy.update()
+
+    train_metrics.loss = loss.item()
+    train_metrics.grad_norm = grad_norm.item()
+    train_metrics.lr = optimizer.param_groups[0]["lr"]
+    train_metrics.update_s = time.perf_counter() - start_time
+    return train_metrics, output_dict
+
+
+@parser.wrap()
+def train(cfg: TrainPipelineConfig):
+    cfg.validate()
+    logging.info(pformat(cfg.to_dict()))
+
+    if cfg.wandb.enable and cfg.wandb.project:
+        wandb_logger = WandBLogger(cfg)
+    else:
+        wandb_logger = None
+        logging.info(colored("Logs will be saved locally.", "yellow", attrs=["bold"]))
+
+    if cfg.seed is not None:
+        set_seed(cfg.seed)
+
+    # Check device is available
+    device = get_safe_torch_device(cfg.policy.device, log=True)
+    torch.backends.cudnn.benchmark = True
+    torch.backends.cuda.matmul.allow_tf32 = True
+
+    logging.info("Creating dataset")
+    dataset = make_dataset(cfg)
+    # for feature in dataset.meta.info['features']:
+    #     if "images" in feature:
+    #         dataset.meta.info['features'][feature]['shape'] = (3, 224, 224)
+   
+    # Create environment used for evaluating checkpoints during training on simulation data.
+    # On real-world data, no need to create an environment as evaluations are done outside train.py,
+    # using the eval.py instead, with gym_dora environment and dora-rs.
+    eval_env = None
+    if cfg.eval_freq > 0 and cfg.env is not None:
+        logging.info("Creating env")
+        eval_env = make_env(cfg.env, n_envs=cfg.eval.batch_size, use_async_envs=cfg.eval.use_async_envs)
+
+    logging.info("Creating policy")
+    policy = make_policy(
+        cfg=cfg.policy,
+        ds_meta=dataset.meta,
+    )
+
+    logging.info("Creating optimizer and scheduler")
+    optimizer, lr_scheduler = make_optimizer_and_scheduler(cfg, policy)
+    grad_scaler = GradScaler(device.type, enabled=cfg.policy.use_amp)
+
+    step = 0  # number of policy updates (forward + backward + optim)
+
+    if cfg.resume:
+        step, optimizer, lr_scheduler = load_training_state(cfg.checkpoint_path, optimizer, lr_scheduler)
+
+    num_learnable_params = sum(p.numel() for p in policy.parameters() if p.requires_grad)
+    num_total_params = sum(p.numel() for p in policy.parameters())
+
+    logging.info(colored("Output dir:", "yellow", attrs=["bold"]) + f" {cfg.output_dir}")
+    if cfg.env is not None:
+        logging.info(f"{cfg.env.task=}")
+    logging.info(f"{cfg.steps=} ({format_big_number(cfg.steps)})")
+    logging.info(f"{dataset.num_frames=} ({format_big_number(dataset.num_frames)})")
+    logging.info(f"{dataset.num_episodes=}")
+    logging.info(f"{num_learnable_params=} ({format_big_number(num_learnable_params)})")
+    logging.info(f"{num_total_params=} ({format_big_number(num_total_params)})")
+
+    # create dataloader for offline training
+    if hasattr(cfg.policy, "drop_n_last_frames"):
+        shuffle = False
+        sampler = EpisodeAwareSampler(
+            dataset.episode_data_index,
+            drop_n_last_frames=cfg.policy.drop_n_last_frames,
+            shuffle=True,
+        )
+    else:
+        shuffle = True
+        sampler = None
+
+    dataloader = torch.utils.data.DataLoader(
+        dataset,
+        num_workers=cfg.num_workers,
+        batch_size=cfg.batch_size,
+        shuffle=shuffle,
+        sampler=sampler,
+        pin_memory=device.type != "cpu",
+        drop_last=False,
+    )
+    dl_iter = cycle(dataloader)
+
+    policy.train()
+
+    train_metrics = {
+        "loss": AverageMeter("loss", ":.3f"),
+        "grad_norm": AverageMeter("grdn", ":.3f"),
+        "lr": AverageMeter("lr", ":0.1e"),
+        "update_s": AverageMeter("updt_s", ":.3f"),
+        "dataloading_s": AverageMeter("data_s", ":.3f"),
+    }
+
+    train_tracker = MetricsTracker(
+        cfg.batch_size, dataset.num_frames, dataset.num_episodes, train_metrics, initial_step=step
+    )
+
+    logging.info("Start offline training on a fixed dataset")
+    for _ in range(step, cfg.steps):
+        start_time = time.perf_counter()
+        batch = next(dl_iter)
+        train_tracker.dataloading_s = time.perf_counter() - start_time
+        
+        # for obs_key in batch:
+        #     if 'images' in obs_key:
+        #         if 'is_pad' in obs_key:
+        #             continue
+        #         batch[obs_key] = resize_with_pad_train(batch[obs_key], 224, 224)
+        
+        for key in batch:
+            if isinstance(batch[key], torch.Tensor):
+                batch[key] = batch[key].to(device, non_blocking=True)
+        
+        train_tracker, output_dict = update_policy(
+            train_tracker,
+            policy,
+            batch,
+            optimizer,
+            cfg.optimizer.grad_clip_norm,
+            grad_scaler=grad_scaler,
+            lr_scheduler=lr_scheduler,
+            use_amp=cfg.policy.use_amp,
+        )
+
+        # Note: eval and checkpoint happens *after* the `step`th training update has completed, so we
+        # increment `step` here.
+        step += 1
+        train_tracker.step()
+        is_log_step = cfg.log_freq > 0 and step % cfg.log_freq == 0
+        is_saving_step = step % cfg.save_freq == 0 or step == cfg.steps
+        is_eval_step = cfg.eval_freq > 0 and step % cfg.eval_freq == 0
+
+        if is_log_step:
+            logging.info(train_tracker)
+            if wandb_logger:
+                wandb_log_dict = train_tracker.to_dict()
+                if output_dict:
+                    wandb_log_dict.update(output_dict)
+                wandb_logger.log_dict(wandb_log_dict, step)
+            train_tracker.reset_averages()
+
+        if cfg.save_checkpoint and is_saving_step:
+            logging.info(f"Checkpoint policy after step {step}")
+            checkpoint_dir = get_step_checkpoint_dir(cfg.output_dir, cfg.steps, step)
+            save_checkpoint(checkpoint_dir, step, cfg, policy, optimizer, lr_scheduler)
+            update_last_checkpoint(checkpoint_dir)
+            if wandb_logger:
+                wandb_logger.log_policy(checkpoint_dir)
+
+        if cfg.env and is_eval_step:
+            step_id = get_step_identifier(step, cfg.steps)
+            logging.info(f"Eval policy at step {step}")
+            with (
+                torch.no_grad(),
+                torch.autocast(device_type=device.type) if cfg.policy.use_amp else nullcontext(),
+            ):
+                eval_info = eval_policy(
+                    eval_env,
+                    policy,
+                    cfg.eval.n_episodes,
+                    videos_dir=cfg.output_dir / "eval" / f"videos_step_{step_id}",
+                    max_episodes_rendered=4,
+                    start_seed=cfg.seed,
+                )
+
+            eval_metrics = {
+                "avg_sum_reward": AverageMeter("∑rwrd", ":.3f"),
+                "pc_success": AverageMeter("success", ":.1f"),
+                "eval_s": AverageMeter("eval_s", ":.3f"),
+            }
+            eval_tracker = MetricsTracker(
+                cfg.batch_size, dataset.num_frames, dataset.num_episodes, eval_metrics, initial_step=step
+            )
+            eval_tracker.eval_s = eval_info["aggregated"].pop("eval_s")
+            eval_tracker.avg_sum_reward = eval_info["aggregated"].pop("avg_sum_reward")
+            eval_tracker.pc_success = eval_info["aggregated"].pop("pc_success")
+            logging.info(eval_tracker)
+            if wandb_logger:
+                wandb_log_dict = {**eval_tracker.to_dict(), **eval_info}
+                wandb_logger.log_dict(wandb_log_dict, step, mode="eval")
+                wandb_logger.log_video(eval_info["video_paths"][0], step, mode="eval")
+
+    if eval_env:
+        eval_env.close()
+    logging.info("End of training")
+
+
+if __name__ == "__main__":
+    init_logging()
+    train()

--- a/lerobot/scripts/train_robocasa_no_pad.py
+++ b/lerobot/scripts/train_robocasa_no_pad.py
@@ -186,6 +186,7 @@ def train(cfg: TrainPipelineConfig):
         shuffle=shuffle,
         sampler=sampler,
         pin_memory=device.type != "cpu",
+        pin_memory_device=device.type,
         drop_last=False,
     )
     dl_iter = cycle(dataloader)

--- a/lerobot/scripts/wait_infer_server.py
+++ b/lerobot/scripts/wait_infer_server.py
@@ -1,0 +1,39 @@
+import sys
+import os
+import time
+import websockets.sync.client
+from lerobot.common.utils.msgpack_utils import unpackb
+
+def get_try_round(default=60):
+    try:
+        return int(os.environ.get('TRY_ROUND', default))
+    except Exception:
+        return default
+
+host = os.environ.get('INFER_SERVER_HOST')
+port = os.environ.get('INFER_SERVER_PORT')
+if not host or not port:
+    print('[ERROR] INFER_SERVER_HOST or INFER_SERVER_PORT not set')
+    sys.exit(1)
+
+ws_url = f'ws://{host}:{port}/'
+try_round = get_try_round()
+
+for i in range(try_round):
+    try:
+        print(f'[INFO] Attempt {i+1}: Connecting to {ws_url}')
+        ws = websockets.sync.client.connect(ws_url, compression=None, max_size=None)
+        try:
+            msg = unpackb(ws.recv())
+            print(f'[SUCCESS] Infer-server is ready. Received message: {msg}')
+            ws.close()
+            sys.exit(0)
+        except Exception as e:
+            print(f'[ERROR] Failed to receive or unpack message: {e}')
+    except Exception as e:
+        print(f'[WARN] Connection attempt failed: {e}')
+    time.sleep(2)
+
+print(f'[ERROR] Infer-server not ready after {try_round} attempts.')
+sys.exit(1)
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dynamixel = ["dynamixel-sdk>=3.7.31", "pynput>=1.7.7"]
 feetech = ["feetech-servo-sdk>=1.0.0", "pynput>=1.7.7"]
 intelrealsense = ["pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'"]
 pi0 = ["transformers>=4.48.0"]
+serving = ["websockets==14.1", "msgpack==1.1.0", "tyro"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [
     "hello-robot-stretch-body>=0.7.27 ; python_version < '4.0' and sys_platform == 'linux'",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ classifiers = [
 ]
 dependencies = [
     "cmake>=3.29.0.1",
-    "datasets>=2.19.0",
+    "datasets>=2.19.0,<4.0.0",
     "deepdiff>=7.0.1",
     "diffusers>=0.27.2",
     "draccus>=0.10.0",
@@ -68,11 +68,13 @@ dependencies = [
     "pyzmq>=26.2.1",
     "rerun-sdk>=0.21.0",
     "termcolor>=2.4.0",
-    "torch>=2.2.1",
+    "torch==2.6.0",
     "torchcodec>=0.2.1; sys_platform != 'win32' and (sys_platform != 'linux' or (platform_machine != 'aarch64' and platform_machine != 'arm64' and platform_machine != 'armv7l')) and (sys_platform != 'darwin' or platform_machine != 'x86_64')",
-    "torchvision>=0.21.0",
+    "torchvision==0.21.0",
     "wandb>=0.16.3",
     "zarr>=2.17.0",
+    "accelerate>=1.7.0",
+    "numpy==1.26.4",
 ]
 
 [project.optional-dependencies]
@@ -85,7 +87,8 @@ dynamixel = ["dynamixel-sdk>=3.7.31", "pynput>=1.7.7"]
 feetech = ["feetech-servo-sdk>=1.0.0", "pynput>=1.7.7"]
 intelrealsense = ["pyrealsense2>=2.55.1.6486 ; sys_platform != 'darwin'"]
 pi0 = ["transformers>=4.48.0"]
-serving = ["websockets==14.1", "msgpack==1.1.0", "tyro"]
+serving = ["websockets==14.1", "msgpack==1.1.0", "tyro", "pytest"]
+npu = ["torch_npu==2.6.0rc1"]
 pusht = ["gym-pusht>=0.1.5 ; python_version < '4.0'"]
 stretch = [
     "hello-robot-stretch-body>=0.7.27 ; python_version < '4.0' and sys_platform == 'linux'",

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+policy_type="$1"
+policy_url="$2"
+
+# Validate parameters
+if [[ -z "$policy_type" || -z "$policy_url" ]]; then
+    echo "Usage: $0 <policy_type> <policy_url>"
+    echo "Example: $0 act obs://bucket/path/to/prefix"
+    exit 1
+fi
+
+# Print the received parameters
+echo "Received policy_type: $policy_type"
+echo "Received policy_url : $policy_url"
+
+python lerobot/scripts/serving_policy.py --policy.type=$policy_type --policy.path=$policy_url

--- a/tests/serving/test_websocket_serving.py
+++ b/tests/serving/test_websocket_serving.py
@@ -1,0 +1,43 @@
+import logging
+import time
+
+import numpy as np
+import websockets.sync.client
+
+import lerobot.common.utils.msgpack_utils as msgpack_utils
+
+input = {
+    "state": np.ones((13,)),
+    "images": {
+        # input images from client has spec h w c (client)
+        "front": np.random.randint(256, size=(480, 640, 3), dtype=np.uint8),
+        "wrist_right": np.random.randint(256, size=(480, 640, 3), dtype=np.uint8),
+    },
+    "prompt": "do something",
+}
+
+url = "ws://127.0.0.1:8000"
+packer = msgpack_utils.Packer()
+
+logging.info(f"Waiting for server at {url}...")
+while True:
+    try:
+        conn = websockets.sync.client.connect(url, compression=None, max_size=None)
+        metadata = msgpack_utils.unpackb(conn.recv())
+        break
+    except ConnectionRefusedError:
+        logging.info("Still waiting for server...")
+        time.sleep(5)
+        
+data = packer.pack(input)
+conn.send(data)
+response = conn.recv()
+if isinstance(response, str):
+    # we're expecting bytes; if the server sends a string, it's an error.
+    print(f"Error in inference server:\n{response}")
+    exit()
+
+infer_result = msgpack_utils.unpackb(response)
+print(infer_result)
+assert len(infer_result['actions'][0]) == len(input['state'])
+

--- a/tests/serving/test_websocket_serving.py
+++ b/tests/serving/test_websocket_serving.py
@@ -38,6 +38,6 @@ if isinstance(response, str):
     exit()
 
 infer_result = msgpack_utils.unpackb(response)
-print(infer_result)
+print(infer_result['actions'].shape, infer_result)
 assert len(infer_result['actions'][0]) == len(input['state'])
 

--- a/tests/serving/test_websocket_serving.py
+++ b/tests/serving/test_websocket_serving.py
@@ -7,11 +7,11 @@ import websockets.sync.client
 import lerobot.common.utils.msgpack_utils as msgpack_utils
 
 input = {
-    "state": np.ones((13,)),
+    "state": np.ones((17,)),
     "images": {
         # input images from client has spec h w c (client)
-        "front": np.random.randint(256, size=(480, 640, 3), dtype=np.uint8),
-        "wrist_right": np.random.randint(256, size=(480, 640, 3), dtype=np.uint8),
+        "front": np.random.randint(256, size=(360, 640, 3), dtype=np.uint8),
+        "wrist_right": np.random.randint(256, size=(360, 640, 3), dtype=np.uint8),
     },
     "prompt": "do something",
 }
@@ -28,16 +28,17 @@ while True:
     except ConnectionRefusedError:
         logging.info("Still waiting for server...")
         time.sleep(5)
-        
-data = packer.pack(input)
-conn.send(data)
-response = conn.recv()
-if isinstance(response, str):
-    # we're expecting bytes; if the server sends a string, it's an error.
-    print(f"Error in inference server:\n{response}")
-    exit()
 
-infer_result = msgpack_utils.unpackb(response)
-print(infer_result['actions'].shape, infer_result)
-assert len(infer_result['actions'][0]) == len(input['state'])
+for i in range(100):
+    data = packer.pack(input)
+    conn.send(data)
+    response = conn.recv()
+    if isinstance(response, str):
+        # we're expecting bytes; if the server sends a string, it's an error.
+        print(f"Error in inference server:\n{response}")
+        exit()
+
+    infer_result = msgpack_utils.unpackb(response)
+    print(infer_result['actions'].shape, infer_result)
+    assert len(infer_result['actions'][0]) == len(input['state'])
 


### PR DESCRIPTION
## Add websocket serving and open-loop evaluation

1. Add websocket serving which is compatible with the openpi client
2. Add open-loop evaluation

## Usage
1. websocket serving
```bash
python lerobot/scripts/serving_policy.py --policy.type=act --policy.path=./outputs/train/act_move_reel_0322_nodepth_nogripper/checkpoints/100000/pretrained_model
```

2. open-loop evaluation
the current open-loop eval implementation reuse `TrainPipelineConfig` in `train.py`, so an additional  
```bash
python lerobot/scripts/openloop_eval.py  --dataset.root=data/move_reel_test_0322 --dataset.repo_id=move_reel_test_0322 --resume=true --config_path=outputs/train/act_move_reel_0322_nodepth/checkpoints/040000/pretrained_model --batch_size=1 --policy.n_action_steps=1
```